### PR TITLE
chore: add watch scripts

### DIFF
--- a/crates/fervid_napi/package.json
+++ b/crates/fervid_napi/package.json
@@ -45,6 +45,7 @@
   },
   "scripts": {
     "artifacts": "napi artifacts",
+    "dev": "cargo watch -w . -w .. -s './watch.sh'",
     "bench": "node -r @swc-node/register benchmark/bench.ts",
     "build": "napi build --platform --release --pipe \"prettier -w\"",
     "build:debug": "napi build --platform --pipe \"prettier -w\"",

--- a/crates/fervid_napi/watch.sh
+++ b/crates/fervid_napi/watch.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yarn build


### PR DESCRIPTION
Since we often need to link local actual projects to run fervid to verify the correctness of fervid, I think we need to add a watch script to make it easier for us to write the code and test it manually every time. I often use it in farm. I just need to install `cargo-watch` and run `yarn dev` in fervid's package.