### PR TITLE
fix: prevent dev scripts from endless loops

### DIFF
--- a/crates/fervid_napi/package.json
+++ b/crates/fervid_napi/package.json
@@ -45,7 +45,7 @@
   },
   "scripts": {
     "artifacts": "napi artifacts",
-    "dev": "cargo watch -w . -w .. -s './watch.sh'",
+    "dev": "chmod +x watch.sh && cargo watch -w '../../crates' -i '*.js' -i '*.d.ts' -s './watch.sh'",
     "bench": "node -r @swc-node/register benchmark/bench.ts",
     "build": "napi build --platform --release --pipe \"prettier -w\"",
     "build:debug": "napi build --platform --pipe \"prettier -w\"",


### PR DESCRIPTION
Since the napi build regenerates the dts file and js file every time, I think cargo watch may judge whether the file has changed based on the file stats, so even if the code has not changed, the file modification time has changed, causing an endless loop to trigger the script every time.