### PR TITLE
fix(#71): fix patch flag on Fragment with multiple roots

### DIFF
--- a/crates/fervid_napi/__tests__/__snapshots__/importUsageCheck.spec.ts.snap
+++ b/crates/fervid_napi/__tests__/__snapshots__/importUsageCheck.spec.ts.snap
@@ -19,7 +19,7 @@ export default _defineComponent({
             (_openBlock(), _createElementBlock(_Fragment, null, _renderList(_ctx.list as Fred, ({
                 z=x as Qux
             })=>_createElementVNode("div")), 256))
-        ]));
+        ], 64));
     },
     setup (__props, { expose: __expose }) {
         __expose();
@@ -79,7 +79,7 @@ export default _defineComponent({
             _createVNode(FooQux),
             _createVNode(foo),
             _createTextVNode(" FooBar ")
-        ]));
+        ], 64));
     },
     setup (__props, { expose: __expose }) {
         __expose();
@@ -144,7 +144,7 @@ export default _defineComponent({
             _createVNode(FooBar, {
                 msg: msg
             })
-        ]));
+        ], 64));
     },
     setup (__props, { expose: __expose }) {
         __expose();
@@ -202,7 +202,7 @@ export default _defineComponent({
         return (_openBlock(), _createElementBlock(_Fragment, null, [
             _createVNode(FooBaz),
             _createVNode(Last)
-        ]));
+        ], 64));
     },
     setup (__props, { expose: __expose }) {
         __expose();
@@ -335,7 +335,7 @@ export default _defineComponent({
             _createVNode(Baz, {
                 ref: "bar"
             }, null, 512)
-        ]));
+        ], 64));
     },
     setup (__props, { expose: __expose }) {
         __expose();

--- a/crates/fervid_napi/__tests__/__snapshots__/templateTransformAssetUrl.spec.ts.snap
+++ b/crates/fervid_napi/__tests__/__snapshots__/templateTransformAssetUrl.spec.ts.snap
@@ -66,7 +66,7 @@ export default {
             _createVNode(_component_use, {
                 href: _imports_0 + "#fragment"
             })
-        ]));
+        ], 64));
     }
 };
 "
@@ -115,7 +115,7 @@ export default {
             _createElementVNode("img", {
                 src: "data:image/png;base64,i"
             })
-        ]));
+        ], 64));
     }
 };
 "
@@ -141,7 +141,7 @@ export default {
             _createElementVNode("img", {
                 src: _imports_1
             })
-        ]));
+        ], 64));
     }
 };
 "
@@ -167,7 +167,7 @@ export default {
             _createElementVNode("img", {
                 src: "//foo.bar/baz.png"
             })
-        ]));
+        ], 64));
     }
 };
 "


### PR DESCRIPTION
Closes #71

This fixes the patch flags on a root-level Fragment when used with multiple roots.
