### PR TITLE
feat(#31): implement basic compileTemplate tests

### DIFF
--- a/crates/fervid_core/src/vue_imports.rs
+++ b/crates/fervid_core/src/vue_imports.rs
@@ -57,6 +57,8 @@ flags! {
         Teleport,
         #[strum(serialize = "_toDisplayString")]
         ToDisplayString,
+        #[strum(serialize = "_toHandlerKey")]
+        ToHandlerKey,
         #[strum(serialize = "_Transition")]
         Transition,
         #[strum(serialize = "_TransitionGroup")]

--- a/crates/fervid_napi/__tests__/__snapshots__/compileTemplate.spec.ts.snap
+++ b/crates/fervid_napi/__tests__/__snapshots__/compileTemplate.spec.ts.snap
@@ -1,0 +1,28 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`dynamic v-on + static v-on should merged 1`] = `
+"import { createElementBlock as _createElementBlock, openBlock as _openBlock, toHandlerKey as _toHandlerKey } from "vue";
+export default {
+    __name: "example",
+    render (_ctx, _cache, $props, $setup, $data, $options) {
+        return (_openBlock(), _createElementBlock("input", {
+            onBlur: (...args)=>_ctx.onBlur && _ctx.onBlur(...args),
+            [_toHandlerKey(_ctx.validateEvent)]: (...args)=>_ctx.onValidateEvent && _ctx.onValidateEvent(...args)
+        }));
+    }
+};
+"
+`;
+
+exports[`should work 1`] = `
+"import { createElementBlock as _createElementBlock, createElementVNode as _createElementVNode, openBlock as _openBlock, toDisplayString as _toDisplayString } from "vue";
+export default {
+    __name: "example",
+    render (_ctx, _cache, $props, $setup, $data, $options) {
+        return (_openBlock(), _createElementBlock("div", null, [
+            _createElementVNode("p", null, _toDisplayString(_ctx.render), 1)
+        ]));
+    }
+};
+"
+`;

--- a/crates/fervid_napi/__tests__/compileTemplate.spec.ts
+++ b/crates/fervid_napi/__tests__/compileTemplate.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from 'vitest'
+import { Compiler } from '..'
+
+// Spec: https://github.com/vuejs/core/blob/532cfae34996676846bf511e1f0f0bf963186e7b/packages/compiler-sfc/__tests__/compileTemplate.spec.ts#L423-L430
+
+interface CompileOptions {
+  source: string
+  filename: string
+}
+
+function compile(opts: CompileOptions) {
+  const source = `<template>${opts.source}</template>`
+
+  const compiler = new Compiler()
+  const result = compiler.compileSync(source, {
+    filename: opts.filename,
+    id: ''
+  })
+
+  return result
+}
+
+test('should work', () => {
+  const source = `<div><p>{{ render }}</p></div>`
+
+  const result = compile({ filename: 'example.vue', source })
+
+  expect(result.errors.length).toBe(0)
+  // expect(result.source).toBe(source)
+  // should expose render fn
+  // expect(result.code).toMatch(`export function render(`)
+  expect(result.code).toMatch(`render (_ctx`)
+
+  expect(result.code).toMatchSnapshot()
+})
+
+// #6742
+test('dynamic v-on + static v-on should merged', () => {
+  const source = `<input @blur="onBlur" @[validateEvent]="onValidateEvent">`
+
+  const result = compile({ filename: 'example.vue', source })
+
+  expect(result.code).toMatchSnapshot()
+})


### PR DESCRIPTION
This contributes to #31 by adding the first `compileTemplate` tests and adding support for `toHandlerKey`
