### PR TITLE
fix: use dynamic public path in playground build

### DIFF
--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -397,6 +397,8 @@ jobs:
 
       - name: Build playground
         run: pnpm build
+        env:
+          PUBLIC_PATH: /fervid/
 
       - name: Upload GitHub Pages artifact
         if: ${{ github.ref == 'refs/heads/master' }}

--- a/node/playground/farm.config.ts
+++ b/node/playground/farm.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from '@farmfe/core'
 import monacoEditorEsmPlugin from 'vite-plugin-monaco-editor-esm'
 
+const PUBLIC_PATH = process.env.PUBLIC_PATH || '/'
+
 export default defineConfig({
     compilation: {
         presetEnv: true,
@@ -9,7 +11,7 @@ export default defineConfig({
         },
         output: {
             path: 'dist',
-            publicPath: './',
+            publicPath: PUBLIC_PATH,
             targetEnv: 'browser'
         },
         define: {


### PR DESCRIPTION
This applies [suggestion](https://github.com/farm-fe/farm/issues/2223#issuecomment-3228718861) to use dynamic paths when building the playground
