### PR TITLE
feat(#29): add basic LSP with support for Nuxt

### DIFF
--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -269,7 +269,7 @@ jobs:
           image: ${{ steps.docker.outputs.IMAGE }}
           name: test-bindings-${{ matrix.target }}
           options: -v ${{ env.WORKING_DIR_PATH }}:/build -w /build -e CI=true --platform ${{ steps.docker.outputs.PLATFORM }}
-          args: corepack enable && yarn test
+          args: '"corepack enable && yarn test"'
 
   test-wasi:
     name: Test WASI target

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -264,11 +264,12 @@ jobs:
       - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
         if: ${{ contains(matrix.target, 'armv7') }}
       - name: Test bindings
-        uses: addnab/docker-run-action@v3
+        uses: tj-actions/docker-run@v2
         with:
           image: ${{ steps.docker.outputs.IMAGE }}
+          name: test-bindings-${{ matrix.target }}
           options: -v ${{ env.WORKING_DIR_PATH }}:/build -w /build -e CI=true --platform ${{ steps.docker.outputs.PLATFORM }}
-          run: corepack enable && yarn test
+          args: corepack enable && yarn test
 
   test-wasi:
     name: Test WASI target

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -269,7 +269,7 @@ jobs:
           image: ${{ steps.docker.outputs.IMAGE }}
           name: test-bindings-${{ matrix.target }}
           options: -v ${{ env.WORKING_DIR_PATH }}:/build -w /build -e CI=true --platform ${{ steps.docker.outputs.PLATFORM }}
-          args: '"corepack enable && yarn test"'
+          args: 'sh -c "corepack enable && yarn test"'
 
   test-wasi:
     name: Test WASI target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,6 +1061,7 @@ dependencies = [
  "env_logger",
  "fervid_core",
  "fervid_parser",
+ "fervid_transform",
  "fxhash",
  "log",
  "ropey",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +170,17 @@ checksum = "a1e2cddd48eafd883890770673b1971faceaf80a185445671abc3ea0c00593ee"
 dependencies = [
  "quote",
  "swc_macros_common 1.0.1",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
  "syn 2.0.106",
 ]
 
@@ -425,7 +486,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -438,6 +499,12 @@ dependencies = [
  "textwrap 0.11.0",
  "unicode-width 0.1.14",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compact_str"
@@ -663,6 +730,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,10 +853,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "farm_plugin_vue_fervid"
@@ -796,7 +910,7 @@ checksum = "7ff6b96a717ec5cc1957be237464805730fb0e02ec5bf2128b632868bcc9f939"
 dependencies = [
  "blake2",
  "bytecheck 0.7.0",
- "dashmap",
+ "dashmap 5.5.3",
  "downcast-rs",
  "enhanced-magic-string",
  "farmfe_macro_cache_item",
@@ -940,6 +1054,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "fervid_lsp"
+version = "0.1.0"
+dependencies = [
+ "dashmap 6.1.0",
+ "env_logger",
+ "fervid_core",
+ "fervid_parser",
+ "fxhash",
+ "log",
+ "ropey",
+ "serde",
+ "serde_json",
+ "swc_core",
+ "swc_ecma_parser 22.0.3",
+ "tokio",
+ "tower-lsp",
+]
+
+[[package]]
 name = "fervid_napi"
 version = "0.2.0"
 dependencies = [
@@ -1049,6 +1182,83 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "fxhash"
@@ -1199,6 +1409,12 @@ dependencies = [
  "rustc-hash 2.1.1",
  "triomphe",
 ]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "iana-time-zone"
@@ -1389,6 +1605,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1429,6 +1651,30 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "js-sys"
@@ -1521,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libloading"
@@ -1566,6 +1812,19 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "lsp-types"
+version = "0.94.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
 
 [[package]]
 name = "memchr"
@@ -1633,6 +1892,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1768,6 +2038,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1897,10 +2173,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plotters"
@@ -1940,6 +2242,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1963,7 +2280,7 @@ dependencies = [
  "ahash 0.8.12",
  "anyhow",
  "browserslist-rs",
- "dashmap",
+ "dashmap 5.5.3",
  "from_variant 0.1.9",
  "once_cell",
  "semver 1.0.26",
@@ -2194,6 +2511,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ropey"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93411e420bcd1a75ddd1dc3caf18c23155eda2c090631a85af21ba19e97093b5"
+dependencies = [
+ "smallvec",
+ "str_indices",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2339,6 +2666,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2354,6 +2692,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-abstraction"
@@ -2383,6 +2731,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2397,6 +2751,16 @@ dependencies = [
  "autocfg",
  "static_assertions",
  "version_check",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2444,7 +2808,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2463,6 +2827,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "str_indices"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08889ec5408683408db66ad89e0e1f93dff55c73a4ccc71c427d5b277ee47e6"
 
 [[package]]
 name = "string_cache"
@@ -2921,7 +3291,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea78032fb75e641906b1cabf88b6b3f26fb2457f1e4799bf3562a6e94372637"
 dependencies = [
  "auto_impl",
- "dashmap",
+ "dashmap 5.5.3",
  "par-core",
  "parking_lot",
  "regex",
@@ -3343,6 +3713,107 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokio"
+version = "1.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-lsp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "bytes",
+ "dashmap 5.5.3",
+ "futures",
+ "httparse",
+ "lsp-types",
+ "memchr",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-lsp-macros",
+ "tracing",
+]
+
+[[package]]
+name = "tower-lsp-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3446,6 +3917,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -3453,6 +3925,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -3639,7 +4117,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3656,7 +4134,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -3690,12 +4168,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -3704,7 +4188,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -3714,6 +4198,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3738,7 +4240,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Currently in alpha stage, the closest goal is to reach feature-parity with the c
 ## Getting started
 Instructions on how to use `fervid` in Vue CLI and Vite are coming very soon!
 
+### Editor support
+
+Fervid includes an experimental Language Server (`fervid_lsp`) with fast Nuxt-oriented completion and go-to-definition. See [`crates/fervid_lsp/README.md`](./crates/fervid_lsp/README.md) for installation and setup.
 
 ## Progress till MVP ![84%](https://geps.dev/progress/84)
 A minimal target of this project includes (see [Roadmap](#roadmap)):

--- a/crates/fervid/src/errors.rs
+++ b/crates/fervid/src/errors.rs
@@ -23,7 +23,10 @@ pub enum CompileError {
 
 impl std::fmt::Display for CompileError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        match self {
+            CompileError::SfcParse(parse_error) => write!(f, "{parse_error}"),
+            CompileError::TransformError(transform_error) => write!(f, "{transform_error}"),
+        }
     }
 }
 

--- a/crates/fervid/src/lib.rs
+++ b/crates/fervid/src/lib.rs
@@ -65,11 +65,7 @@ pub use fervid_transform::{
     style::should_transform_style_block, transform_sfc, PropsDestructureConfig, SetupBinding,
     TransformSfcOptions,
 };
-use fxhash::FxHasher32;
-use std::{
-    borrow::Cow,
-    hash::{Hash, Hasher},
-};
+use std::borrow::Cow;
 use swc_core::{common::FileName, ecma::ast::Expr};
 
 // TODO Add severity to errors
@@ -149,12 +145,7 @@ pub fn compile(source: &str, options: CompileOptions) -> Result<CompileResult, C
 
     // For scopes
     // TODO Research if it's better to compute that on the caller site or here
-    let file_hash = {
-        let mut hasher = FxHasher32::default();
-        source.hash(&mut hasher);
-        let num = hasher.finish();
-        format!("{:x}", num)
-    };
+    let file_hash = compute_scope_id(source);
 
     // Transform
     let mut transform_errors = Vec::new();
@@ -246,12 +237,7 @@ pub fn compile_sync_naive(source: &str, is_prod: bool) -> Result<String, String>
     let sfc = parser.parse_sfc().map_err(|err| err.to_string())?;
 
     // For scopes
-    let file_hash = {
-        let mut hasher = FxHasher32::default();
-        source.hash(&mut hasher);
-        let num = hasher.finish();
-        format!("{:x}", num)
-    };
+    let file_hash = compute_scope_id(source);
 
     // Transform
     let mut transform_errors = Vec::new();

--- a/crates/fervid_core/src/sfc.rs
+++ b/crates/fervid_core/src/sfc.rs
@@ -2,7 +2,7 @@ use swc_core::{common::Span, ecma::ast::Module};
 
 use crate::{FervidAtom, Node, StartingTag};
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct SfcDescriptor {
     pub template: Option<SfcTemplateBlock>,
     pub script_legacy: Option<SfcScriptBlock>,

--- a/crates/fervid_core/src/utils.rs
+++ b/crates/fervid_core/src/utils.rs
@@ -1,3 +1,6 @@
+use std::hash::{Hash, Hasher};
+
+use fxhash::FxHasher32;
 use swc_core::{
     common::Span,
     ecma::ast::{ComputedPropName, EsReserved, Ident, IdentName, PropName, Str},
@@ -70,4 +73,11 @@ pub fn str_or_expr_to_propname(str_or_expr: StrOrExpr, span: Span) -> PropName {
         StrOrExpr::Str(sym) => atom_to_propname(sym, span),
         StrOrExpr::Expr(expr) => PropName::Computed(ComputedPropName { span, expr }),
     }
+}
+
+pub fn compute_scope_id(source: &str) -> String {
+    let mut hasher = FxHasher32::default();
+    source.hash(&mut hasher);
+    let num = hasher.finish();
+    format!("{:x}", num)
 }

--- a/crates/fervid_lsp/Cargo.toml
+++ b/crates/fervid_lsp/Cargo.toml
@@ -9,6 +9,7 @@ dashmap = "6.1.0"
 env_logger = "0.11.8"
 fervid_core = { path="../fervid_core", version = "0.2" }
 fervid_parser = { path="../fervid_parser", version = "0.2" }
+fervid_transform = { path="../fervid_transform", version = "0.2" }
 fxhash = { workspace = true }
 log = "0.4.27"
 ropey = "1.6.1"

--- a/crates/fervid_lsp/Cargo.toml
+++ b/crates/fervid_lsp/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "fervid_lsp"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+dashmap = "6.1.0"
+env_logger = "0.11.8"
+fervid_core = { path="../fervid_core", version = "0.2" }
+fervid_parser = { path="../fervid_parser", version = "0.2" }
+fxhash = { workspace = true }
+log = "0.4.27"
+ropey = "1.6.1"
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.142"
+swc_core = { workspace = true, features = ["common", "ecma_ast"] }
+swc_ecma_parser = { workspace = true }
+tokio = { version = "1.47.1", features = ["full"] }
+tower-lsp = { version = "0.20.0", features = ["proposed"] }

--- a/crates/fervid_lsp/README.md
+++ b/crates/fervid_lsp/README.md
@@ -1,11 +1,33 @@
 ## fervid_lsp crate (experimental)
 
-Install (very early phase, currently only from within cloned repository):
+`fervid_lsp` is an experimental Language Server for Vue / Nuxt projects built as a part of Fervid project.
+It focuses on fast, practical editor features (completion + go-to-definition), especially around Nuxt auto-imports and components.
+
+### Status
+
+- ✅ Nuxt globals: completions + go-to-definition via `.nuxt/imports.d.ts` and `.nuxt/components.d.ts`
+- ✅ Local analysis: uses Fervid's `transform_sfc` pipeline to collect bindings and template scopes
+- ✅ Parsing and transformation error diagnostics
+- ⚠️ Still evolving: better diagnostics and better `<template>` support
+
+### Install
+
+Install directly from GitHub (no local clone required):
+
 ```sh
-cargo install --path crates/fervid_lsp --locked
+cargo install --git https://github.com/phoenix-ru/fervid --locked --path crates/fervid_lsp
 ```
 
-Use in Neovim:
+For a specific branch:
+
+```sh
+cargo install --git https://github.com/phoenix-ru/fervid --branch feat/29-implement-lsp-for-nuxt --locked --path crates/fervid_lsp
+```
+
+### Neovim setup
+
+Use it in Neovim with this minimal config:
+
 ```lua
 local capabilities = require('cmp_nvim_lsp').default_capabilities(vim.lsp.protocol.make_client_capabilities())
 
@@ -16,4 +38,19 @@ vim.lsp.config('fervid_lsp', {
   root_markers = { "package.json", ".git" },
 })
 vim.lsp.enable('fervid_lsp')
+```
+
+### Usage alongside `vue_ls`
+
+Neovim will query *all* attached LSP servers for `textDocument/definition`.
+If another Vue/TS server is slow or returns empty results slowly (such as `vue_ls` on large projects), you can disable its definition capability for Vue buffers:
+
+```lua
+vim.lsp.config('vue_ls', {
+  -- ... other options
+  on_attach = function(client)
+    -- Disable goto-definition
+    client.server_capabilities.definitionProvider = false
+  end,
+})
 ```

--- a/crates/fervid_lsp/README.md
+++ b/crates/fervid_lsp/README.md
@@ -1,0 +1,19 @@
+## fervid_lsp crate (experimental)
+
+Install (very early phase, currently only from within cloned repository):
+```sh
+cargo install --path crates/fervid_lsp --locked
+```
+
+Use in Neovim:
+```lua
+local capabilities = require('cmp_nvim_lsp').default_capabilities(vim.lsp.protocol.make_client_capabilities())
+
+vim.lsp.config('fervid_lsp', {
+  cmd = { "fervid_lsp" },
+  capabilities = capabilities,
+  filetypes = { 'vue' },
+  root_markers = { "package.json", ".git" },
+})
+vim.lsp.enable('fervid_lsp')
+```

--- a/crates/fervid_lsp/src/change.rs
+++ b/crates/fervid_lsp/src/change.rs
@@ -52,21 +52,38 @@ pub async fn on_change<'a>(backend: &Backend, params: TextDocumentItem<'a>) {
     // 4. Do SFC transformation in the background to not block CPU
     let client = backend.client.clone();
     let analysis_map = backend.analysis_map.clone();
-    let uri = params.uri.clone();
     let version = params.version;
     let file_hash = compute_scope_id(params.text);
 
     task::spawn(async move {
-        let mut transform_errors = Vec::new();
-        let transform_options = TransformSfcOptions {
-            is_prod: true,
-            is_ce: false,
-            props_destructure: fervid_transform::PropsDestructureConfig::True,
-            scope_id: &file_hash,
-            filename: uri.as_str(),
-            transform_asset_urls: fervid_transform::TransformAssetUrlsConfig::Disabled,
+        // TODO: Evaluate the use of `rayon` here - `transform_sfc` is already incredibly fast
+        let transform_result = task::spawn_blocking(move || {
+            let mut transform_errors = Vec::new();
+            let transform_options = TransformSfcOptions {
+                is_prod: true,
+                is_ce: false,
+                props_destructure: fervid_transform::PropsDestructureConfig::True,
+                scope_id: &file_hash,
+                filename: &uri_key,
+                transform_asset_urls: fervid_transform::TransformAssetUrlsConfig::Disabled,
+            };
+            (
+                transform_sfc(sfc, transform_options, &mut transform_errors),
+                transform_errors,
+            )
+        })
+        .await;
+
+        let Ok((transform_result, transform_errors)) = transform_result else {
+            // join error (panic inside blocking task)
+            let _ = client
+                .log_message(
+                    tower_lsp::lsp_types::MessageType::ERROR,
+                    "transform_sfc task panicked",
+                )
+                .await;
+            return;
         };
-        let transform_result = transform_sfc(sfc, transform_options, &mut transform_errors);
 
         if !transform_errors.is_empty() {
             let diagnostics = transform_errors
@@ -94,7 +111,7 @@ pub async fn on_change<'a>(backend: &Backend, params: TextDocumentItem<'a>) {
             template_block: transform_result.template_block,
         };
 
-        analysis_map.insert(uri.to_string(), Arc::new(analysis));
+        analysis_map.insert(params.uri.to_string(), Arc::new(analysis));
 
         // backend.semantic_token_map
         //     .insert(params.uri.to_string(), semantic_tokens);

--- a/crates/fervid_lsp/src/change.rs
+++ b/crates/fervid_lsp/src/change.rs
@@ -1,0 +1,117 @@
+use std::sync::Arc;
+
+use crate::{
+    offset_to_position,
+    structs::{Backend, DocumentAnalysis, TextDocumentItem},
+};
+use fervid_core::{compute_scope_id, SfcDescriptor};
+use fervid_parser::{ParseError, SfcParser};
+use fervid_transform::{transform_sfc, TransformSfcOptions};
+use ropey::Rope;
+use swc_core::common::Spanned;
+use tokio::task;
+use tower_lsp::lsp_types::{Diagnostic, Range};
+
+pub async fn on_change<'a>(backend: &Backend, params: TextDocumentItem<'a>) {
+    let uri_key = params.uri.to_string();
+
+    // 1. Store rope immediately (fast path)
+    let rope = Rope::from_str(params.text);
+    backend.document_map.insert(uri_key.clone(), rope.clone());
+
+    // 2. Parse SFC (sync) and publish diagnostics immediately
+    let (sfc_opt, sfc_parsing_errors) = parse(params.text);
+
+    let diagnostics = sfc_parsing_errors
+        .into_iter()
+        .filter_map(|parse_error| {
+            let message = parse_error.kind.to_string();
+            let span = parse_error.span;
+            let start_position = offset_to_position(span.lo.0 as usize, &rope)?;
+            let end_position = offset_to_position(span.hi.0 as usize, &rope)?;
+            Some(Diagnostic::new_simple(
+                Range::new(start_position, end_position),
+                message,
+            ))
+        })
+        .collect::<Vec<_>>();
+
+    backend
+        .client
+        .publish_diagnostics(params.uri.clone(), diagnostics, params.version)
+        .await;
+
+    // 3.1. If parse failed, do NOT overwrite previous ast/analysis
+    let Some(sfc) = sfc_opt else {
+        return;
+    };
+
+    // 3.2. Store the initial unprocessed descriptor for finding cursor locations
+    backend.ast_map.insert(uri_key.clone(), sfc.clone());
+
+    // 4. Do SFC transformation in the background to not block CPU
+    let client = backend.client.clone();
+    let analysis_map = backend.analysis_map.clone();
+    let uri = params.uri.clone();
+    let version = params.version;
+    let file_hash = compute_scope_id(params.text);
+
+    task::spawn(async move {
+        let mut transform_errors = Vec::new();
+        let transform_options = TransformSfcOptions {
+            is_prod: true,
+            is_ce: false,
+            props_destructure: fervid_transform::PropsDestructureConfig::True,
+            scope_id: &file_hash,
+            filename: uri.as_str(),
+            transform_asset_urls: fervid_transform::TransformAssetUrlsConfig::Disabled,
+        };
+        let transform_result = transform_sfc(sfc, transform_options, &mut transform_errors);
+
+        if !transform_errors.is_empty() {
+            let diagnostics = transform_errors
+                .into_iter()
+                .filter_map(|transform_error| {
+                    let message = transform_error.to_string();
+                    let span = transform_error.span();
+                    let start_position = offset_to_position(span.lo.0 as usize, &rope)?;
+                    let end_position = offset_to_position(span.hi.0 as usize, &rope)?;
+                    Some(Diagnostic::new_simple(
+                        Range::new(start_position, end_position),
+                        message,
+                    ))
+                })
+                .collect::<Vec<_>>();
+
+            client
+                .publish_diagnostics(params.uri.clone(), diagnostics, params.version)
+                .await;
+        }
+
+        let analysis = DocumentAnalysis {
+            version,
+            bindings: Arc::new(transform_result.bindings_helper),
+            template_block: transform_result.template_block,
+        };
+
+        analysis_map.insert(uri.to_string(), Arc::new(analysis));
+
+        // backend.semantic_token_map
+        //     .insert(params.uri.to_string(), semantic_tokens);
+    });
+}
+
+fn parse(input: &str) -> (Option<SfcDescriptor>, Vec<ParseError>) {
+    let mut sfc_parsing_errors = Vec::new();
+
+    let mut parser = SfcParser::new(input, &mut sfc_parsing_errors);
+    let sfc = match parser.parse_sfc() {
+        Ok(sfc) => Some(sfc),
+        Err(e) => {
+            sfc_parsing_errors.push(e);
+            None
+        }
+    };
+
+    (sfc, sfc_parsing_errors)
+}

--- a/crates/fervid_lsp/src/completion.rs
+++ b/crates/fervid_lsp/src/completion.rs
@@ -1,7 +1,7 @@
 use fervid_core::FervidAtom;
 use serde_json::json;
 use tower_lsp::jsonrpc::{Error, ErrorCode, Result};
-use tower_lsp::lsp_types::{Position, Url};
+use tower_lsp::lsp_types::{CompletionItem, InsertTextFormat, Position, Url};
 
 use crate::utils::extract_prefix;
 use crate::{
@@ -10,10 +10,27 @@ use crate::{
     Backend,
 };
 
-pub enum FervidCompletionItem {
-    Component { name: FervidAtom },
-    Prop { name: FervidAtom },
-    Import { name: FervidAtom },
+pub struct FervidCompletionItem {
+    name: FervidAtom,
+    kind: CompletionItemKind,
+    source_kind: CompletionSourceKind,
+    source_origin: Option<FervidAtom>,
+}
+
+#[derive(Clone, Copy)]
+pub enum CompletionItemKind {
+    Component,
+    Import,
+    #[allow(dead_code)]
+    Prop,
+}
+
+pub enum CompletionSourceKind {
+    /// Completions retrieved from Nuxt metadata (auto-imports and components)
+    Nuxt,
+    /// Completions retrieved from the current file
+    #[allow(dead_code)]
+    Local,
 }
 
 pub fn provide_completions(
@@ -42,7 +59,7 @@ pub fn provide_completions(
 
     let prefix = extract_prefix(&rope, cursor_char);
 
-    let doc_path = uri_to_path(&uri).ok_or(Error {
+    let doc_path = uri_to_path(uri).ok_or(Error {
         code: ErrorCode::InvalidParams,
         message: "Unable to resolve completion path as file".into(),
         data: Some(json!(uri.as_str())),
@@ -77,22 +94,88 @@ pub fn completion_from_globals(globals: &NuxtGlobals, prefix: &str) -> Vec<Fervi
     let mut result = Vec::new();
 
     // Components
-    for name in globals.components.keys() {
+    for (name, target) in globals.components.iter() {
         if prefix.is_empty() || name.starts_with(prefix) {
-            result.push(FervidCompletionItem::Component {
+            result.push(FervidCompletionItem {
                 name: name.as_str().into(),
+                kind: CompletionItemKind::Component,
+                source_kind: CompletionSourceKind::Nuxt,
+                source_origin: Some(target.spec.to_owned()),
             });
         }
     }
 
     // Imports
-    for name in globals.imports.keys() {
+    for (name, target) in globals.imports.iter() {
         if prefix.is_empty() || name.starts_with(prefix) {
-            result.push(FervidCompletionItem::Import {
+            result.push(FervidCompletionItem {
                 name: name.as_str().into(),
+                kind: CompletionItemKind::Import,
+                source_kind: CompletionSourceKind::Nuxt,
+                source_origin: Some(target.spec.to_owned()),
             });
         }
     }
 
     result
+}
+
+impl From<FervidCompletionItem> for tower_lsp::lsp_types::CompletionItem {
+    fn from(val: FervidCompletionItem) -> Self {
+        let name = val.name.to_string();
+        let label = name.clone();
+        let detail = Some(format_detail(val.source_kind, val.kind, val.source_origin));
+
+        match val.kind {
+            CompletionItemKind::Component => CompletionItem {
+                label,
+                kind: Some(tower_lsp::lsp_types::CompletionItemKind::CLASS),
+                insert_text: Some(name),
+                detail,
+                ..Default::default()
+            },
+            CompletionItemKind::Prop => CompletionItem {
+                label,
+                kind: Some(tower_lsp::lsp_types::CompletionItemKind::VARIABLE),
+                insert_text: Some(format!("{}=\"$1\"", name)),
+                insert_text_format: Some(InsertTextFormat::SNIPPET),
+                detail,
+                ..Default::default()
+            },
+            CompletionItemKind::Import => CompletionItem {
+                label,
+                kind: Some(tower_lsp::lsp_types::CompletionItemKind::FUNCTION),
+                insert_text: Some(name),
+                detail,
+                ..Default::default()
+            },
+        }
+    }
+}
+
+fn format_detail(
+    source_kind: CompletionSourceKind,
+    completion_kind: CompletionItemKind,
+    source_origin: Option<FervidAtom>,
+) -> String {
+    let prefix = format_source_prefix(source_kind, completion_kind);
+    if let Some(source_origin) = source_origin {
+        format!("{prefix} from {source_origin}")
+    } else {
+        prefix.to_string()
+    }
+}
+
+fn format_source_prefix(
+    source_kind: CompletionSourceKind,
+    completion_kind: CompletionItemKind,
+) -> &'static str {
+    match (source_kind, completion_kind) {
+        (CompletionSourceKind::Local, CompletionItemKind::Component) => "Local component",
+        (CompletionSourceKind::Local, CompletionItemKind::Import) => "Import",
+        (CompletionSourceKind::Local, CompletionItemKind::Prop) => "Prop",
+        (CompletionSourceKind::Nuxt, CompletionItemKind::Component) => "Nuxt component",
+        (CompletionSourceKind::Nuxt, CompletionItemKind::Import) => "Nuxt auto-import",
+        (CompletionSourceKind::Nuxt, CompletionItemKind::Prop) => "Prop",
+    }
 }

--- a/crates/fervid_lsp/src/completion.rs
+++ b/crates/fervid_lsp/src/completion.rs
@@ -1,4 +1,6 @@
 use fervid_core::FervidAtom;
+use fervid_transform::BindingsHelper;
+use fxhash::FxHashMap;
 use serde_json::json;
 use tower_lsp::jsonrpc::{Error, ErrorCode, Result};
 use tower_lsp::lsp_types::{CompletionItem, InsertTextFormat, Position, Url};
@@ -23,6 +25,7 @@ pub enum CompletionItemKind {
     Import,
     #[allow(dead_code)]
     Prop,
+    Variable,
 }
 
 pub enum CompletionSourceKind {
@@ -38,14 +41,13 @@ pub fn provide_completions(
     position: &Position,
     uri: &Url,
 ) -> Result<Vec<FervidCompletionItem>> {
-    let rope = backend
-        .document_map
-        .get(&uri.to_string())
-        .ok_or_else(|| Error {
-            code: ErrorCode::InvalidParams,
-            message: "Unable to find contents of a file".into(),
-            data: Some(json!(uri.as_str())),
-        })?;
+    let uri_key = uri.to_string();
+
+    let rope = backend.document_map.get(&uri_key).ok_or_else(|| Error {
+        code: ErrorCode::InvalidParams,
+        message: "Unable to find contents of a file".into(),
+        data: Some(json!(uri.as_str())),
+    })?;
 
     // TODO: this is not UTF-16 safe, LSP seems to use UTF-16, but ropey seemingly uses chars
     let line_start_char = rope
@@ -79,45 +81,81 @@ pub fn provide_completions(
 
     let root_key = root.to_string_lossy().to_string();
 
+    let mut result = FxHashMap::default();
+
+    // Global completions from Nuxt
     let globals = backend.nuxt_globals.get(&root_key).ok_or_else(|| Error {
         code: ErrorCode::ServerError(-33012),
         message: "Unable to find workspace root data".into(),
         data: Some(json!(root_key)),
     })?;
+    completion_from_globals(&globals, &prefix, &mut result);
 
-    Ok(completion_from_globals(&globals, &prefix))
+    // Local document completions
+    if let Some(analysis) = backend.analysis_map.get(&uri_key) {
+        completion_from_setup_bindings(&analysis.bindings, &prefix, &mut result);
+    }
+
+    Ok(result.into_values().collect())
 }
 
 /// Naive implementation of completions using prefix matching from globals.
 /// It is naive in a sense that it does not consider the surrounding context (are we inside `<script>` or `<template>`)
-pub fn completion_from_globals(globals: &NuxtGlobals, prefix: &str) -> Vec<FervidCompletionItem> {
-    let mut result = Vec::new();
-
+pub fn completion_from_globals(
+    globals: &NuxtGlobals,
+    prefix: &str,
+    out: &mut FxHashMap<FervidAtom, FervidCompletionItem>,
+) {
     // Components
     for (name, target) in globals.components.iter() {
         if prefix.is_empty() || name.starts_with(prefix) {
-            result.push(FervidCompletionItem {
-                name: name.as_str().into(),
-                kind: CompletionItemKind::Component,
-                source_kind: CompletionSourceKind::Nuxt,
-                source_origin: Some(target.spec.to_owned()),
-            });
+            out.insert(
+                name.to_owned(),
+                FervidCompletionItem {
+                    name: name.as_str().into(),
+                    kind: CompletionItemKind::Component,
+                    source_kind: CompletionSourceKind::Nuxt,
+                    source_origin: Some(target.spec.to_owned()),
+                },
+            );
         }
     }
 
     // Imports
     for (name, target) in globals.imports.iter() {
         if prefix.is_empty() || name.starts_with(prefix) {
-            result.push(FervidCompletionItem {
-                name: name.as_str().into(),
-                kind: CompletionItemKind::Import,
-                source_kind: CompletionSourceKind::Nuxt,
-                source_origin: Some(target.spec.to_owned()),
-            });
+            out.insert(
+                name.to_owned(),
+                FervidCompletionItem {
+                    name: name.to_owned(),
+                    kind: CompletionItemKind::Import,
+                    source_kind: CompletionSourceKind::Nuxt,
+                    source_origin: Some(target.spec.to_owned()),
+                },
+            );
         }
     }
+}
 
-    result
+pub fn completion_from_setup_bindings(
+    bindings: &BindingsHelper,
+    prefix: &str,
+    out: &mut FxHashMap<FervidAtom, FervidCompletionItem>,
+) {
+    for b in bindings.setup_bindings.iter() {
+        let name = &b.sym; // FervidAtom
+        if prefix.is_empty() || name.as_ref().starts_with(prefix) {
+            out.insert(
+                name.to_owned(),
+                FervidCompletionItem {
+                    name: name.to_owned(),
+                    kind: CompletionItemKind::Variable,
+                    source_kind: CompletionSourceKind::Local,
+                    source_origin: None,
+                },
+            );
+        }
+    }
 }
 
 impl From<FervidCompletionItem> for tower_lsp::lsp_types::CompletionItem {
@@ -149,6 +187,13 @@ impl From<FervidCompletionItem> for tower_lsp::lsp_types::CompletionItem {
                 detail,
                 ..Default::default()
             },
+            CompletionItemKind::Variable => CompletionItem {
+                label,
+                kind: Some(tower_lsp::lsp_types::CompletionItemKind::VARIABLE),
+                insert_text: Some(name),
+                detail,
+                ..Default::default()
+            },
         }
     }
 }
@@ -174,8 +219,10 @@ fn format_source_prefix(
         (CompletionSourceKind::Local, CompletionItemKind::Component) => "Local component",
         (CompletionSourceKind::Local, CompletionItemKind::Import) => "Import",
         (CompletionSourceKind::Local, CompletionItemKind::Prop) => "Prop",
+        (CompletionSourceKind::Local, CompletionItemKind::Variable) => "Variable",
         (CompletionSourceKind::Nuxt, CompletionItemKind::Component) => "Nuxt component",
         (CompletionSourceKind::Nuxt, CompletionItemKind::Import) => "Nuxt auto-import",
         (CompletionSourceKind::Nuxt, CompletionItemKind::Prop) => "Prop",
+        (CompletionSourceKind::Nuxt, CompletionItemKind::Variable) => "Variable",
     }
 }

--- a/crates/fervid_lsp/src/completion.rs
+++ b/crates/fervid_lsp/src/completion.rs
@@ -1,0 +1,98 @@
+use fervid_core::FervidAtom;
+use serde_json::json;
+use tower_lsp::jsonrpc::{Error, ErrorCode, Result};
+use tower_lsp::lsp_types::{Position, Url};
+
+use crate::utils::extract_prefix;
+use crate::{
+    nuxt::NuxtGlobals,
+    utils::{pick_workspace_root, uri_to_path},
+    Backend,
+};
+
+pub enum FervidCompletionItem {
+    Component { name: FervidAtom },
+    Prop { name: FervidAtom },
+    Import { name: FervidAtom },
+}
+
+pub fn provide_completions(
+    backend: &Backend,
+    position: &Position,
+    uri: &Url,
+) -> Result<Vec<FervidCompletionItem>> {
+    let rope = backend
+        .document_map
+        .get(&uri.to_string())
+        .ok_or_else(|| Error {
+            code: ErrorCode::InvalidParams,
+            message: "Unable to find contents of a file".into(),
+            data: Some(json!(uri.as_str())),
+        })?;
+
+    // TODO: this is not UTF-16 safe, LSP seems to use UTF-16, but ropey seemingly uses chars
+    let line_start_char = rope
+        .try_line_to_char(position.line as usize)
+        .map_err(|_| Error {
+            code: ErrorCode::InvalidParams,
+            message: "Unable to convert line to character index".into(),
+            data: Some(json!(uri.as_str())),
+        })?;
+    let cursor_char = line_start_char + position.character as usize;
+
+    let prefix = extract_prefix(&rope, cursor_char);
+
+    let doc_path = uri_to_path(&uri).ok_or(Error {
+        code: ErrorCode::InvalidParams,
+        message: "Unable to resolve completion path as file".into(),
+        data: Some(json!(uri.as_str())),
+    })?;
+
+    let roots = backend.workspace_roots.try_read().map_err(|_| Error {
+        code: ErrorCode::ServerError(-33010),
+        message: "Unable to acquire lock on workspace_roots".into(),
+        data: None,
+    })?;
+
+    let root = pick_workspace_root(&roots, &doc_path).ok_or_else(|| Error {
+        code: ErrorCode::ServerError(-33011),
+        message: "Unable to pick workspace root for file".into(),
+        data: Some(json!(doc_path)),
+    })?;
+
+    let root_key = root.to_string_lossy().to_string();
+
+    let globals = backend.nuxt_globals.get(&root_key).ok_or_else(|| Error {
+        code: ErrorCode::ServerError(-33012),
+        message: "Unable to find workspace root data".into(),
+        data: Some(json!(root_key)),
+    })?;
+
+    Ok(completion_from_globals(&globals, &prefix))
+}
+
+/// Naive implementation of completions using prefix matching from globals.
+/// It is naive in a sense that it does not consider the surrounding context (are we inside `<script>` or `<template>`)
+pub fn completion_from_globals(globals: &NuxtGlobals, prefix: &str) -> Vec<FervidCompletionItem> {
+    let mut result = Vec::new();
+
+    // Components
+    for name in globals.components.keys() {
+        if prefix.is_empty() || name.starts_with(prefix) {
+            result.push(FervidCompletionItem::Component {
+                name: name.as_str().into(),
+            });
+        }
+    }
+
+    // Imports
+    for name in globals.imports.keys() {
+        if prefix.is_empty() || name.starts_with(prefix) {
+            result.push(FervidCompletionItem::Import {
+                name: name.as_str().into(),
+            });
+        }
+    }
+
+    result
+}

--- a/crates/fervid_lsp/src/definition.rs
+++ b/crates/fervid_lsp/src/definition.rs
@@ -1,10 +1,14 @@
+use fervid_core::FervidAtom;
 use serde_json::json;
 use tower_lsp::{
     jsonrpc::{Error, ErrorCode, Result},
     lsp_types::{GotoDefinitionResponse, Location, Position, Range, Url},
 };
 
-use crate::{Backend, nuxt::resolver::resolve_from_nuxt_dir, utils::{extract_token_at, normalize_path, pick_workspace_root, uri_to_path}};
+use crate::{
+    utils::{extract_token_at, pick_workspace_root, uri_to_path},
+    Backend,
+};
 
 pub fn goto_definition(
     backend: &Backend,
@@ -30,12 +34,12 @@ pub fn goto_definition(
         })?;
     let cursor_char = line_start_char + position.character as usize;
 
-    let token = extract_token_at(&rope, cursor_char);
+    let token = FervidAtom::from(extract_token_at(&rope, cursor_char));
     if token.is_empty() {
         return Ok(None);
     }
 
-    let doc_path = uri_to_path(&uri).ok_or(Error {
+    let doc_path = uri_to_path(uri).ok_or(Error {
         code: ErrorCode::InvalidParams,
         message: "Unable to resolve completion path as file".into(),
         data: Some(json!(uri.as_str())),
@@ -61,16 +65,22 @@ pub fn goto_definition(
         data: Some(json!(root_key)),
     })?;
 
-    let Some(import_path) = globals.components.get(&token) else {
+    let Some(nuxt_global_target) = globals
+        .components
+        .get(&token)
+        .or_else(|| globals.imports.get(&token))
+    else {
         return Ok(None);
     };
 
-    let target_path = normalize_path(resolve_from_nuxt_dir(root, import_path));
+    let Some(ref resolved_target_path) = nuxt_global_target.resolved else {
+        return Ok(None);
+    };
 
-    let target_uri = Url::from_file_path(&target_path).map_err(|_| Error {
+    let target_uri = Url::from_file_path(resolved_target_path).map_err(|_| Error {
         code: ErrorCode::ServerError(-34010),
         message: "Unable to convert file path to URI".into(),
-        data: Some(json!(target_path)),
+        data: Some(json!(resolved_target_path)),
     })?;
 
     let loc = Location::new(

--- a/crates/fervid_lsp/src/definition.rs
+++ b/crates/fervid_lsp/src/definition.rs
@@ -1,0 +1,82 @@
+use serde_json::json;
+use tower_lsp::{
+    jsonrpc::{Error, ErrorCode, Result},
+    lsp_types::{GotoDefinitionResponse, Location, Position, Range, Url},
+};
+
+use crate::{Backend, nuxt::resolver::resolve_from_nuxt_dir, utils::{extract_token_at, normalize_path, pick_workspace_root, uri_to_path}};
+
+pub fn goto_definition(
+    backend: &Backend,
+    position: &Position,
+    uri: &Url,
+) -> Result<Option<GotoDefinitionResponse>> {
+    let rope = backend
+        .document_map
+        .get(&uri.to_string())
+        .ok_or_else(|| Error {
+            code: ErrorCode::InvalidParams,
+            message: "Unable to find contents of a file".into(),
+            data: Some(json!(uri.as_str())),
+        })?;
+
+    // TODO: this is not UTF-16 safe, LSP seems to use UTF-16, but ropey seemingly uses chars
+    let line_start_char = rope
+        .try_line_to_char(position.line as usize)
+        .map_err(|_| Error {
+            code: ErrorCode::InvalidParams,
+            message: "Unable to convert line to character index".into(),
+            data: Some(json!(uri.as_str())),
+        })?;
+    let cursor_char = line_start_char + position.character as usize;
+
+    let token = extract_token_at(&rope, cursor_char);
+    if token.is_empty() {
+        return Ok(None);
+    }
+
+    let doc_path = uri_to_path(&uri).ok_or(Error {
+        code: ErrorCode::InvalidParams,
+        message: "Unable to resolve completion path as file".into(),
+        data: Some(json!(uri.as_str())),
+    })?;
+
+    let roots = backend.workspace_roots.try_read().map_err(|_| Error {
+        code: ErrorCode::ServerError(-33010),
+        message: "Unable to acquire lock on workspace_roots".into(),
+        data: None,
+    })?;
+
+    let root = pick_workspace_root(&roots, &doc_path).ok_or_else(|| Error {
+        code: ErrorCode::ServerError(-33011),
+        message: "Unable to pick workspace root for file".into(),
+        data: Some(json!(doc_path)),
+    })?;
+
+    let root_key = root.to_string_lossy().to_string();
+
+    let globals = backend.nuxt_globals.get(&root_key).ok_or_else(|| Error {
+        code: ErrorCode::ServerError(-33012),
+        message: "Unable to find workspace root data".into(),
+        data: Some(json!(root_key)),
+    })?;
+
+    let Some(import_path) = globals.components.get(&token) else {
+        return Ok(None);
+    };
+
+    let target_path = normalize_path(resolve_from_nuxt_dir(root, import_path));
+
+    let target_uri = Url::from_file_path(&target_path).map_err(|_| Error {
+        code: ErrorCode::ServerError(-34010),
+        message: "Unable to convert file path to URI".into(),
+        data: Some(json!(target_path)),
+    })?;
+
+    let loc = Location::new(
+        target_uri,
+        Range::new(Position::new(0, 0), Position::new(0, 0)),
+    );
+
+    Ok(Some(GotoDefinitionResponse::Scalar(loc)))
+}

--- a/crates/fervid_lsp/src/main.rs
+++ b/crates/fervid_lsp/src/main.rs
@@ -1,43 +1,27 @@
-use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
 use dashmap::DashMap;
-use fervid_core::SfcDescriptor;
-use fervid_parser::{ParseError, SfcParser};
 use log::debug;
 use ropey::Rope;
 use serde::{Deserialize, Serialize};
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::notification::Notification;
 use tower_lsp::lsp_types::*;
-use tower_lsp::{Client, LanguageServer, LspService, Server};
+use tower_lsp::{LanguageServer, LspService, Server};
 
+use crate::change::on_change;
 use crate::completion::provide_completions;
 use crate::definition::goto_definition;
 use crate::nuxt::loader::load_nuxt_for_workspaces;
-use crate::nuxt::{NuxtGlobals, NuxtInfo};
+use crate::structs::{Backend, TextDocumentItem};
 use crate::utils::workspace_uri_to_path;
 
+mod change;
 mod completion;
 mod definition;
 mod nuxt;
+mod structs;
 mod utils;
-
-type WorkspaceKey = String;
-
-#[derive(Debug)]
-struct Backend {
-    client: Client,
-    ast_map: DashMap<String, SfcDescriptor>,
-    // semantic_map: DashMap<String, Semantic>,
-    document_map: DashMap<String, Rope>,
-    // semantic_token_map: DashMap<String, Vec<ImCompleteSemanticToken>>,
-    workspace_roots: RwLock<Vec<PathBuf>>,
-
-    // Nuxt-specific
-    nuxt_info: DashMap<WorkspaceKey, Arc<NuxtInfo>>,
-    nuxt_globals: DashMap<WorkspaceKey, Arc<NuxtGlobals>>,
-}
 
 #[tower_lsp::async_trait]
 impl LanguageServer for Backend {
@@ -140,20 +124,26 @@ impl LanguageServer for Backend {
 
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
         debug!("file opened");
-        self.on_change(TextDocumentItem {
-            uri: params.text_document.uri,
-            text: &params.text_document.text,
-            version: Some(params.text_document.version),
-        })
+        on_change(
+            self,
+            TextDocumentItem {
+                uri: params.text_document.uri,
+                text: &params.text_document.text,
+                version: Some(params.text_document.version),
+            },
+        )
         .await
     }
 
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
-        self.on_change(TextDocumentItem {
-            text: &params.content_changes[0].text,
-            uri: params.text_document.uri,
-            version: Some(params.text_document.version),
-        })
+        on_change(
+            self,
+            TextDocumentItem {
+                text: &params.content_changes[0].text,
+                uri: params.text_document.uri,
+                version: Some(params.text_document.version),
+            },
+        )
         .await
     }
 
@@ -165,7 +155,7 @@ impl LanguageServer for Backend {
                 text: &text,
                 version: None,
             };
-            self.on_change(item).await;
+            on_change(self, item).await;
             _ = self.client.semantic_tokens_refresh().await;
         }
         debug!("file saved!");
@@ -544,79 +534,6 @@ impl Notification for CustomNotification {
     type Params = InlayHintParams;
     const METHOD: &'static str = "custom/notification";
 }
-struct TextDocumentItem<'a> {
-    uri: Url,
-    text: &'a str,
-    version: Option<i32>,
-}
-
-impl Backend {
-    async fn on_change<'a>(&self, params: TextDocumentItem<'a>) {
-        let rope = Rope::from_str(params.text);
-        self.document_map
-            .insert(params.uri.to_string(), rope.clone());
-
-        let (sfc, sfc_parsing_errors) = parse(params.text);
-
-        let diagnostics = sfc_parsing_errors
-            .into_iter()
-            .filter_map(|parse_error| {
-                let message = parse_error.kind.to_string();
-                let span = parse_error.span;
-                let start_position = offset_to_position(span.lo.0 as usize, &rope)?;
-                let end_position = offset_to_position(span.hi.0 as usize, &rope)?;
-                Some(Diagnostic::new_simple(
-                    Range::new(start_position, end_position),
-                    message,
-                ))
-            })
-            .collect::<Vec<_>>();
-
-        if let Some(ast) = sfc {
-            // match analyze_program(&ast) {
-            //     Ok(semantic) => {
-            //         self.semantic_map.insert(params.uri.to_string(), semantic);
-            //     }
-            //     Err(err) => {
-            //         self.semantic_token_map.remove(&params.uri.to_string());
-            //         let span = err.span();
-            //         let start_position = offset_to_position(span.start, &rope);
-            //         let end_position = offset_to_position(span.end, &rope);
-            //         let diag = start_position
-            //             .and_then(|start| end_position.map(|end| (start, end)))
-            //             .map(|(start, end)| {
-            //                 Diagnostic::new_simple(Range::new(start, end), format!("{err:?}"))
-            //             });
-            //         if let Some(diag) = diag {
-            //             diagnostics.push(diag);
-            //         }
-            //     }
-            // };
-            self.ast_map.insert(params.uri.to_string(), ast);
-        }
-
-        self.client
-            .publish_diagnostics(params.uri.clone(), diagnostics, params.version)
-            .await;
-        // self.semantic_token_map
-        //     .insert(params.uri.to_string(), semantic_tokens);
-    }
-}
-
-fn parse(input: &str) -> (Option<SfcDescriptor>, Vec<ParseError>) {
-    let mut sfc_parsing_errors = Vec::new();
-
-    let mut parser = SfcParser::new(input, &mut sfc_parsing_errors);
-    let sfc = match parser.parse_sfc() {
-        Ok(sfc) => Some(sfc),
-        Err(e) => {
-            sfc_parsing_errors.push(e);
-            None
-        }
-    };
-
-    (sfc, sfc_parsing_errors)
-}
 
 #[tokio::main]
 async fn main() {
@@ -627,7 +544,8 @@ async fn main() {
 
     let (service, socket) = LspService::build(|client| Backend {
         client,
-        ast_map: DashMap::new(),
+        analysis_map: Arc::new(DashMap::new()),
+        ast_map: Arc::new(DashMap::new()),
         document_map: DashMap::new(),
         // semantic_token_map: DashMap::new(),
         // semantic_map: DashMap::new(),

--- a/crates/fervid_lsp/src/main.rs
+++ b/crates/fervid_lsp/src/main.rs
@@ -1,0 +1,712 @@
+use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
+
+use dashmap::DashMap;
+use fervid_core::SfcDescriptor;
+use fervid_parser::{ParseError, SfcParser};
+use log::debug;
+use ropey::Rope;
+use serde::{Deserialize, Serialize};
+use tower_lsp::jsonrpc::Result;
+use tower_lsp::lsp_types::notification::Notification;
+use tower_lsp::lsp_types::*;
+use tower_lsp::{Client, LanguageServer, LspService, Server};
+
+use crate::completion::{provide_completions, FervidCompletionItem};
+use crate::definition::goto_definition;
+use crate::nuxt::loader::load_nuxt_for_workspaces;
+use crate::nuxt::{NuxtGlobals, NuxtInfo};
+use crate::utils::workspace_uri_to_path;
+
+mod completion;
+mod definition;
+mod nuxt;
+mod utils;
+
+type WorkspaceKey = String;
+
+#[derive(Debug)]
+struct Backend {
+    client: Client,
+    ast_map: DashMap<String, SfcDescriptor>,
+    // semantic_map: DashMap<String, Semantic>,
+    document_map: DashMap<String, Rope>,
+    // semantic_token_map: DashMap<String, Vec<ImCompleteSemanticToken>>,
+    workspace_roots: RwLock<Vec<PathBuf>>,
+
+    // Nuxt-specific
+    nuxt_info: DashMap<WorkspaceKey, Arc<NuxtInfo>>,
+    nuxt_globals: DashMap<WorkspaceKey, Arc<NuxtGlobals>>,
+}
+
+#[tower_lsp::async_trait]
+impl LanguageServer for Backend {
+    async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
+        if let Some(workspace_folders) = params.workspace_folders {
+            load_nuxt_for_workspaces(self, &workspace_folders).await;
+
+            // Save workspace roots
+            let roots = workspace_folders
+                .into_iter()
+                .filter_map(|workspace_folder| workspace_uri_to_path(&workspace_folder))
+                .collect();
+
+            match self.workspace_roots.try_write() {
+                Ok(mut lock) => {
+                    *lock = roots;
+                }
+                Err(error) => {
+                    log::error!("Error acquiring lock on workspace_roots {}", error);
+                }
+            }
+        }
+
+        Ok(InitializeResult {
+            server_info: None,
+            offset_encoding: None,
+            capabilities: ServerCapabilities {
+                // inlay_hint_provider: Some(OneOf::Left(true)),
+                text_document_sync: Some(TextDocumentSyncCapability::Options(
+                    TextDocumentSyncOptions {
+                        open_close: Some(true),
+                        change: Some(TextDocumentSyncKind::FULL),
+                        save: Some(TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
+                            include_text: Some(true),
+                        })),
+                        ..Default::default()
+                    },
+                )),
+                completion_provider: Some(CompletionOptions {
+                    resolve_provider: Some(false),
+                    trigger_characters: Some(vec![".".to_string()]),
+                    work_done_progress_options: Default::default(),
+                    all_commit_characters: None,
+                    completion_item: None,
+                }),
+                // execute_command_provider: Some(ExecuteCommandOptions {
+                //     commands: vec!["dummy.do_something".to_string()],
+                //     work_done_progress_options: Default::default(),
+                // }),
+                workspace: Some(WorkspaceServerCapabilities {
+                    workspace_folders: Some(WorkspaceFoldersServerCapabilities {
+                        supported: Some(true),
+                        change_notifications: Some(OneOf::Left(true)),
+                    }),
+                    file_operations: None,
+                }),
+                // semantic_tokens_provider: Some(
+                //     SemanticTokensServerCapabilities::SemanticTokensRegistrationOptions(
+                //         SemanticTokensRegistrationOptions {
+                //             text_document_registration_options: {
+                //                 TextDocumentRegistrationOptions {
+                //                     document_selector: Some(vec![DocumentFilter {
+                //                         language: Some("nrs".to_string()),
+                //                         scheme: Some("file".to_string()),
+                //                         pattern: None,
+                //                     }]),
+                //                 }
+                //             },
+                //             semantic_tokens_options: SemanticTokensOptions {
+                //                 work_done_progress_options: WorkDoneProgressOptions::default(),
+                //                 legend: SemanticTokensLegend {
+                //                     token_types: LEGEND_TYPE.into(),
+                //                     token_modifiers: vec![],
+                //                 },
+                //                 range: Some(true),
+                //                 full: Some(SemanticTokensFullOptions::Bool(true)),
+                //             },
+                //             static_registration_options: StaticRegistrationOptions::default(),
+                //         },
+                //     ),
+                // ),
+                // definition: Some(GotoCapability::default()),
+                definition_provider: Some(OneOf::Left(true)),
+                // references_provider: Some(OneOf::Left(true)),
+                // rename_provider: Some(OneOf::Left(true)),
+                ..ServerCapabilities::default()
+            },
+        })
+    }
+    async fn initialized(&self, _: InitializedParams) {
+        debug!("initialized!");
+    }
+
+    async fn shutdown(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn did_open(&self, params: DidOpenTextDocumentParams) {
+        debug!("file opened");
+        self.on_change(TextDocumentItem {
+            uri: params.text_document.uri,
+            text: &params.text_document.text,
+            version: Some(params.text_document.version),
+        })
+        .await
+    }
+
+    async fn did_change(&self, params: DidChangeTextDocumentParams) {
+        self.on_change(TextDocumentItem {
+            text: &params.content_changes[0].text,
+            uri: params.text_document.uri,
+            version: Some(params.text_document.version),
+        })
+        .await
+    }
+
+    async fn did_save(&self, params: DidSaveTextDocumentParams) {
+        dbg!(&params.text);
+        if let Some(text) = params.text {
+            let item = TextDocumentItem {
+                uri: params.text_document.uri,
+                text: &text,
+                version: None,
+            };
+            self.on_change(item).await;
+            _ = self.client.semantic_tokens_refresh().await;
+        }
+        debug!("file saved!");
+    }
+    async fn did_close(&self, _: DidCloseTextDocumentParams) {
+        debug!("file closed!");
+    }
+
+    async fn goto_definition(
+        &self,
+        params: GotoDefinitionParams,
+    ) -> Result<Option<GotoDefinitionResponse>> {
+        let uri = params.text_document_position_params.text_document.uri;
+        let position = params.text_document_position_params.position;
+
+        goto_definition(self, &position, &uri)
+    }
+
+    // async fn goto_definition(
+    //     &self,
+    //     params: GotoDefinitionParams,
+    // ) -> Result<Option<GotoDefinitionResponse>> {
+    //     let definition = || -> Option<GotoDefinitionResponse> {
+    //         let uri = params.text_document_position_params.text_document.uri;
+    //         let semantic = self.semantic_map.get(uri.as_str())?;
+    //         let rope = self.document_map.get(uri.as_str())?;
+    //         let position = params.text_document_position_params.position;
+    //         let offset = position_to_offset(position, &rope)?;
+
+    //         let interval = semantic.ident_range.find(offset, offset + 1).next()?;
+    //         let interval_val = interval.val;
+    //         let range = match interval_val {
+    //             IdentType::Binding(symbol_id) => {
+    //                 let span = &semantic.table.symbol_id_to_span[symbol_id];
+    //                 Some(span.clone())
+    //             }
+    //             IdentType::Reference(reference_id) => {
+    //                 let reference = semantic.table.reference_id_to_reference.get(reference_id)?;
+    //                 let symbol_id = reference.symbol_id?;
+    //                 let symbol_range = semantic.table.symbol_id_to_span.get(symbol_id)?;
+    //                 Some(symbol_range.clone())
+    //             }
+    //         };
+
+    //         range.and_then(|range| {
+    //             let start_position = offset_to_position(range.start, &rope)?;
+    //             let end_position = offset_to_position(range.end, &rope)?;
+    //             Some(GotoDefinitionResponse::Scalar(Location::new(
+    //                 uri,
+    //                 Range::new(start_position, end_position),
+    //             )))
+    //         })
+    //     }();
+    //     Ok(definition)
+    // }
+
+    // async fn references(&self, params: ReferenceParams) -> Result<Option<Vec<Location>>> {
+    //     let reference_list = || -> Option<Vec<Location>> {
+    //         let uri = params.text_document_position.text_document.uri;
+    //         let semantic = self.semantic_map.get(uri.as_str())?;
+    //         let rope = self.document_map.get(uri.as_str())?;
+    //         let position = params.text_document_position.position;
+    //         let offset = position_to_offset(position, &rope)?;
+    //         let reference_span_list = get_references(&semantic, offset, offset + 1, false)?;
+
+    //         let ret = reference_span_list
+    //             .into_iter()
+    //             .filter_map(|range| {
+    //                 let start_position = offset_to_position(range.start, &rope)?;
+    //                 let end_position = offset_to_position(range.end, &rope)?;
+
+    //                 let range = Range::new(start_position, end_position);
+
+    //                 Some(Location::new(uri.clone(), range))
+    //             })
+    //             .collect::<Vec<_>>();
+    //         Some(ret)
+    //     }();
+    //     Ok(reference_list)
+    // }
+
+    // async fn semantic_tokens_full(
+    //     &self,
+    //     params: SemanticTokensParams,
+    // ) -> Result<Option<SemanticTokensResult>> {
+    //     let uri = params.text_document.uri.to_string();
+    //     debug!("semantic_token_full");
+    //     let semantic_tokens = || -> Option<Vec<SemanticToken>> {
+    //         let mut im_complete_tokens = self.semantic_token_map.get_mut(&uri)?;
+    //         let rope = self.document_map.get(&uri)?;
+    //         im_complete_tokens.sort_by(|a, b| a.start.cmp(&b.start));
+    //         let mut pre_line = 0;
+    //         let mut pre_start = 0;
+    //         let semantic_tokens = im_complete_tokens
+    //             .iter()
+    //             .filter_map(|token| {
+    //                 let line = rope.try_byte_to_line(token.start).ok()? as u32;
+    //                 let first = rope.try_line_to_char(line as usize).ok()? as u32;
+    //                 let start = rope.try_byte_to_char(token.start).ok()? as u32 - first;
+    //                 let delta_line = line - pre_line;
+    //                 let delta_start = if delta_line == 0 {
+    //                     start - pre_start
+    //                 } else {
+    //                     start
+    //                 };
+    //                 let ret = Some(SemanticToken {
+    //                     delta_line,
+    //                     delta_start,
+    //                     length: token.length as u32,
+    //                     token_type: token.token_type as u32,
+    //                     token_modifiers_bitset: 0,
+    //                 });
+    //                 pre_line = line;
+    //                 pre_start = start;
+    //                 ret
+    //             })
+    //             .collect::<Vec<_>>();
+    //         Some(semantic_tokens)
+    //     }();
+    //     if let Some(semantic_token) = semantic_tokens {
+    //         return Ok(Some(SemanticTokensResult::Tokens(SemanticTokens {
+    //             result_id: None,
+    //             data: semantic_token,
+    //         })));
+    //     }
+    //     Ok(None)
+    // }
+
+    // async fn semantic_tokens_range(
+    //     &self,
+    //     params: SemanticTokensRangeParams,
+    // ) -> Result<Option<SemanticTokensRangeResult>> {
+    //     let uri = params.text_document.uri.to_string();
+    //     let semantic_tokens = || -> Option<Vec<SemanticToken>> {
+    //         let im_complete_tokens = self.semantic_token_map.get(&uri)?;
+    //         let rope = self.document_map.get(&uri)?;
+    //         let mut pre_line = 0;
+    //         let mut pre_start = 0;
+    //         let semantic_tokens = im_complete_tokens
+    //             .iter()
+    //             .filter_map(|token| {
+    //                 let line = rope.try_byte_to_line(token.start).ok()? as u32;
+    //                 let first = rope.try_line_to_char(line as usize).ok()? as u32;
+    //                 let start = rope.try_byte_to_char(token.start).ok()? as u32 - first;
+    //                 let ret = Some(SemanticToken {
+    //                     delta_line: line - pre_line,
+    //                     delta_start: if start >= pre_start {
+    //                         start - pre_start
+    //                     } else {
+    //                         start
+    //                     },
+    //                     length: token.length as u32,
+    //                     token_type: token.token_type as u32,
+    //                     token_modifiers_bitset: 0,
+    //                 });
+    //                 pre_line = line;
+    //                 pre_start = start;
+    //                 ret
+    //             })
+    //             .collect::<Vec<_>>();
+    //         Some(semantic_tokens)
+    //     }();
+    //     Ok(semantic_tokens.map(|data| {
+    //         SemanticTokensRangeResult::Tokens(SemanticTokens {
+    //             result_id: None,
+    //             data,
+    //         })
+    //     }))
+    // }
+
+    // async fn inlay_hint(
+    //     &self,
+    //     params: tower_lsp::lsp_types::InlayHintParams,
+    // ) -> Result<Option<Vec<InlayHint>>> {
+    //     debug!("inlay hint");
+    //     let uri = &params.text_document.uri;
+    //     let mut hashmap = HashMap::new();
+    //     if let Some(ast) = self.ast_map.get(uri.as_str()) {
+    //         ast.iter().for_each(|(func, _)| {
+    //             type_inference(&func.body, &mut hashmap);
+    //         });
+    //     }
+
+    //     let document = match self.document_map.get(uri.as_str()) {
+    //         Some(rope) => rope,
+    //         None => return Ok(None),
+    //     };
+    //     let inlay_hint_list = hashmap
+    //         .into_iter()
+    //         .map(|(k, v)| {
+    //             (
+    //                 k.start,
+    //                 k.end,
+    //                 match v {
+    //                     nrs_language_server::nrs_lang::Value::Null => "null".to_string(),
+    //                     nrs_language_server::nrs_lang::Value::Bool(_) => "bool".to_string(),
+    //                     nrs_language_server::nrs_lang::Value::Num(_) => "number".to_string(),
+    //                     nrs_language_server::nrs_lang::Value::Str(_) => "string".to_string(),
+    //                 },
+    //             )
+    //         })
+    //         .filter_map(|item| {
+    //             // let start_position = offset_to_position(item.0, document)?;
+    //             let end_position = offset_to_position(item.1, &document)?;
+    //             let inlay_hint = InlayHint {
+    //                 text_edits: None,
+    //                 tooltip: None,
+    //                 kind: Some(InlayHintKind::TYPE),
+    //                 padding_left: None,
+    //                 padding_right: None,
+    //                 data: None,
+    //                 position: end_position,
+    //                 label: InlayHintLabel::LabelParts(vec![InlayHintLabelPart {
+    //                     value: item.2,
+    //                     tooltip: None,
+    //                     location: Some(Location {
+    //                         uri: params.text_document.uri.clone(),
+    //                         range: Range {
+    //                             start: Position::new(0, 4),
+    //                             end: Position::new(0, 10),
+    //                         },
+    //                     }),
+    //                     command: None,
+    //                 }]),
+    //             };
+    //             Some(inlay_hint)
+    //         })
+    //         .collect::<Vec<_>>();
+
+    //     Ok(Some(inlay_hint_list))
+    // }
+
+    async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {
+        let uri = params.text_document_position.text_document.uri;
+        let position = params.text_document_position.position;
+
+        let completions = || -> Result<Option<Vec<CompletionItem>>> {
+            let completions = provide_completions(self, &position, &uri)?;
+
+            let mut ret = Vec::with_capacity(completions.len());
+            for item in completions {
+                match item {
+                    FervidCompletionItem::Component { name } => {
+                        let s = name.to_string();
+                        ret.push(CompletionItem {
+                            label: s.clone(),
+                            kind: Some(CompletionItemKind::CLASS),
+                            insert_text: Some(s.clone()),
+                            detail: Some("Nuxt component".into()),
+                            ..Default::default()
+                        });
+                    }
+                    FervidCompletionItem::Prop { name } => {
+                        let s = name.to_string();
+                        ret.push(CompletionItem {
+                            label: s.clone(),
+                            kind: Some(CompletionItemKind::VARIABLE),
+                            insert_text: Some(format!("{}=\"$1\"", s)),
+                            insert_text_format: Some(InsertTextFormat::SNIPPET),
+                            detail: Some("Vue prop".into()),
+                            ..Default::default()
+                        });
+                    }
+                    FervidCompletionItem::Import { name } => {
+                        let s = name.to_string();
+                        ret.push(CompletionItem {
+                            label: s.clone(),
+                            kind: Some(CompletionItemKind::FUNCTION),
+                            insert_text: Some(s.clone()),
+                            detail: Some("Nuxt auto-import".into()),
+                            ..Default::default()
+                        });
+                    }
+                }
+            }
+
+            Ok(Some(ret))
+        }()?;
+
+        Ok(completions.map(CompletionResponse::Array))
+    }
+
+    // async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {
+    //     let uri = params.text_document_position.text_document.uri;
+    //     let position = params.text_document_position.position;
+    //     let completions = || -> Option<Vec<CompletionItem>> {
+    //         let rope = self.document_map.get(&uri.to_string())?;
+    //         let ast = self.ast_map.get(&uri.to_string())?;
+    //         let char = rope.try_line_to_char(position.line as usize).ok()?;
+    //         let offset = char + position.character as usize;
+
+    //         let completions = completion(&ast, offset);
+    //         let mut ret = Vec::with_capacity(completions.len());
+
+    //         for completion in completions {
+    //             match completion {
+    //                 FervidCompletionItem::Component { name } => {
+    //                     // TODO Auto insert required props depending on config?
+
+    //                     let name_string = name.to_string();
+
+    //                     ret.push(CompletionItem {
+    //                         label: name_string.clone(),
+    //                         kind: Some(CompletionItemKind::VARIABLE),
+    //                         insert_text: Some(name_string.clone()),
+    //                         detail: Some(name_string),
+    //                         ..Default::default()
+    //                     });
+    //                 }
+
+    //                 FervidCompletionItem::Prop { name } => {
+    //                     // ret.push(CompletionItem {
+    //                     //     label: name.clone(),
+    //                     //     kind: Some(CompletionItemKind::FUNCTION),
+    //                     //     detail: Some(name.clone()),
+    //                     //     insert_text: Some(format!(
+    //                     //         "{}({})",
+    //                     //         name,
+    //                     //         args.iter()
+    //                     //             .enumerate()
+    //                     //             .map(|(index, item)| { format!("${{{}:{}}}", index + 1, item) })
+    //                     //             .collect::<Vec<_>>()
+    //                     //             .join(",")
+    //                     //     )),
+    //                     //     insert_text_format: Some(InsertTextFormat::SNIPPET),
+    //                     //     ..Default::default()
+    //                     // });
+    //                     let name_string = name.to_string();
+
+    //                     ret.push(CompletionItem {
+    //                         label: name_string.clone(),
+    //                         kind: Some(CompletionItemKind::VARIABLE),
+    //                         insert_text: Some(format!("{}=\"$1\"", name_string)),
+    //                         insert_text_format: Some(InsertTextFormat::SNIPPET),
+    //                         detail: Some(name_string),
+    //                         ..Default::default()
+    //                     });
+    //                 }
+    //             }
+    //         }
+    //         Some(ret)
+    //     }();
+    //     Ok(completions.map(CompletionResponse::Array))
+    // }
+
+    // async fn rename(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
+    //     let workspace_edit = || -> Option<WorkspaceEdit> {
+    //         let uri = params.text_document_position.text_document.uri;
+    //         let semantic = self.semantic_map.get(uri.as_str())?;
+    //         let rope = self.document_map.get(uri.as_str())?;
+    //         let position = params.text_document_position.position;
+    //         let offset = position_to_offset(position, &rope)?;
+    //         let reference_list = get_references(&semantic, offset, offset + 1, true)?;
+
+    //         let new_name = params.new_name;
+    //         (!reference_list.is_empty()).then_some(()).map(|_| {
+    //             let edit_list = reference_list
+    //                 .into_iter()
+    //                 .filter_map(|range| {
+    //                     let start_position = offset_to_position(range.start, &rope)?;
+    //                     let end_position = offset_to_position(range.end, &rope)?;
+    //                     Some(TextEdit::new(
+    //                         Range::new(start_position, end_position),
+    //                         new_name.clone(),
+    //                     ))
+    //                 })
+    //                 .collect::<Vec<_>>();
+    //             let mut map = HashMap::new();
+    //             map.insert(uri, edit_list);
+    //             WorkspaceEdit::new(map)
+    //         })
+    //     }();
+    //     Ok(workspace_edit)
+    // }
+
+    async fn did_change_configuration(&self, _: DidChangeConfigurationParams) {
+        debug!("configuration changed!");
+    }
+
+    async fn did_change_workspace_folders(&self, _: DidChangeWorkspaceFoldersParams) {
+        debug!("workspace folders changed!");
+    }
+
+    async fn did_change_watched_files(&self, _: DidChangeWatchedFilesParams) {
+        debug!("watched files have changed!");
+    }
+
+    // async fn execute_command(&self, _: ExecuteCommandParams) -> Result<Option<Value>> {
+    //     debug!("command executed!");
+
+    //     match self.client.apply_edit(WorkspaceEdit::default()).await {
+    //         Ok(res) if res.applied => self.client.log_message(MessageType::INFO, "applied").await,
+    //         Ok(_) => self.client.log_message(MessageType::INFO, "rejected").await,
+    //         Err(err) => self.client.log_message(MessageType::ERROR, err).await,
+    //     }
+
+    //     Ok(None)
+    // }
+}
+#[derive(Debug, Deserialize, Serialize)]
+struct InlayHintParams {
+    path: String,
+}
+
+#[allow(unused)]
+enum CustomNotification {}
+impl Notification for CustomNotification {
+    type Params = InlayHintParams;
+    const METHOD: &'static str = "custom/notification";
+}
+struct TextDocumentItem<'a> {
+    uri: Url,
+    text: &'a str,
+    version: Option<i32>,
+}
+
+impl Backend {
+    async fn on_change<'a>(&self, params: TextDocumentItem<'a>) {
+        let rope = Rope::from_str(params.text);
+        self.document_map
+            .insert(params.uri.to_string(), rope.clone());
+
+        let (sfc, sfc_parsing_errors) = parse(params.text);
+
+        let diagnostics = sfc_parsing_errors
+            .into_iter()
+            .filter_map(|parse_error| {
+                let message = parse_error.kind.to_string();
+                let span = parse_error.span;
+                let start_position = offset_to_position(span.lo.0 as usize, &rope)?;
+                let end_position = offset_to_position(span.hi.0 as usize, &rope)?;
+                Some(Diagnostic::new_simple(
+                    Range::new(start_position, end_position),
+                    message,
+                ))
+            })
+            .collect::<Vec<_>>();
+
+        if let Some(ast) = sfc {
+            // match analyze_program(&ast) {
+            //     Ok(semantic) => {
+            //         self.semantic_map.insert(params.uri.to_string(), semantic);
+            //     }
+            //     Err(err) => {
+            //         self.semantic_token_map.remove(&params.uri.to_string());
+            //         let span = err.span();
+            //         let start_position = offset_to_position(span.start, &rope);
+            //         let end_position = offset_to_position(span.end, &rope);
+            //         let diag = start_position
+            //             .and_then(|start| end_position.map(|end| (start, end)))
+            //             .map(|(start, end)| {
+            //                 Diagnostic::new_simple(Range::new(start, end), format!("{err:?}"))
+            //             });
+            //         if let Some(diag) = diag {
+            //             diagnostics.push(diag);
+            //         }
+            //     }
+            // };
+            self.ast_map.insert(params.uri.to_string(), ast);
+        }
+
+        self.client
+            .publish_diagnostics(params.uri.clone(), diagnostics, params.version)
+            .await;
+        // self.semantic_token_map
+        //     .insert(params.uri.to_string(), semantic_tokens);
+    }
+}
+
+fn parse(input: &str) -> (Option<SfcDescriptor>, Vec<ParseError>) {
+    let mut sfc_parsing_errors = Vec::new();
+
+    let mut parser = SfcParser::new(input, &mut sfc_parsing_errors);
+    let sfc = match parser.parse_sfc() {
+        Ok(sfc) => Some(sfc),
+        Err(e) => {
+            sfc_parsing_errors.push(e);
+            None
+        }
+    };
+
+    (sfc, sfc_parsing_errors)
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+
+    let (service, socket) = LspService::build(|client| Backend {
+        client,
+        ast_map: DashMap::new(),
+        document_map: DashMap::new(),
+        // semantic_token_map: DashMap::new(),
+        // semantic_map: DashMap::new(),
+        workspace_roots: RwLock::new(vec![]),
+        nuxt_globals: DashMap::new(),
+        nuxt_info: DashMap::new(),
+    })
+    .finish();
+
+    Server::new(stdin, stdout, socket).serve(service).await;
+}
+
+fn offset_to_position(offset: usize, rope: &Rope) -> Option<Position> {
+    let line = rope.try_char_to_line(offset).ok()?;
+    let first_char_of_line = rope.try_line_to_char(line).ok()?;
+    let column = offset - first_char_of_line;
+    Some(Position::new(line as u32, column as u32))
+}
+
+// fn position_to_offset(position: Position, rope: &Rope) -> Option<usize> {
+//     let line_char_offset = rope.try_line_to_char(position.line as usize).ok()?;
+//     let slice = rope.slice(0..line_char_offset + position.character as usize);
+//     Some(slice.len_bytes())
+// }
+
+// fn get_references(
+//     semantic: &Semantic,
+//     start: usize,
+//     end: usize,
+//     include_definition: bool,
+// ) -> Option<Vec<Span>> {
+//     let interval = semantic.ident_range.find(start, end).next()?;
+//     let interval_val = interval.val;
+//     match interval_val {
+//         IdentType::Binding(symbol_id) => {
+//             let references = semantic.table.symbol_id_to_references.get(&symbol_id)?;
+//             let mut reference_span_list: Vec<Span> = references
+//                 .iter()
+//                 .map(|reference_id| {
+//                     semantic.table.reference_id_to_reference[*reference_id]
+//                         .span
+//                         .clone()
+//                 })
+//                 .collect();
+//             if include_definition {
+//                 let symbol_range = semantic.table.symbol_id_to_span.get(symbol_id)?;
+//                 reference_span_list.push(symbol_range.clone());
+//             }
+//             Some(reference_span_list)
+//         }
+//         IdentType::Reference(_) => None,
+//     }
+// }

--- a/crates/fervid_lsp/src/main.rs
+++ b/crates/fervid_lsp/src/main.rs
@@ -405,69 +405,6 @@ impl LanguageServer for Backend {
         Ok(completions.map(CompletionResponse::Array))
     }
 
-    // async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {
-    //     let uri = params.text_document_position.text_document.uri;
-    //     let position = params.text_document_position.position;
-    //     let completions = || -> Option<Vec<CompletionItem>> {
-    //         let rope = self.document_map.get(&uri.to_string())?;
-    //         let ast = self.ast_map.get(&uri.to_string())?;
-    //         let char = rope.try_line_to_char(position.line as usize).ok()?;
-    //         let offset = char + position.character as usize;
-
-    //         let completions = completion(&ast, offset);
-    //         let mut ret = Vec::with_capacity(completions.len());
-
-    //         for completion in completions {
-    //             match completion {
-    //                 FervidCompletionItem::Component { name } => {
-    //                     // TODO Auto insert required props depending on config?
-
-    //                     let name_string = name.to_string();
-
-    //                     ret.push(CompletionItem {
-    //                         label: name_string.clone(),
-    //                         kind: Some(CompletionItemKind::VARIABLE),
-    //                         insert_text: Some(name_string.clone()),
-    //                         detail: Some(name_string),
-    //                         ..Default::default()
-    //                     });
-    //                 }
-
-    //                 FervidCompletionItem::Prop { name } => {
-    //                     // ret.push(CompletionItem {
-    //                     //     label: name.clone(),
-    //                     //     kind: Some(CompletionItemKind::FUNCTION),
-    //                     //     detail: Some(name.clone()),
-    //                     //     insert_text: Some(format!(
-    //                     //         "{}({})",
-    //                     //         name,
-    //                     //         args.iter()
-    //                     //             .enumerate()
-    //                     //             .map(|(index, item)| { format!("${{{}:{}}}", index + 1, item) })
-    //                     //             .collect::<Vec<_>>()
-    //                     //             .join(",")
-    //                     //     )),
-    //                     //     insert_text_format: Some(InsertTextFormat::SNIPPET),
-    //                     //     ..Default::default()
-    //                     // });
-    //                     let name_string = name.to_string();
-
-    //                     ret.push(CompletionItem {
-    //                         label: name_string.clone(),
-    //                         kind: Some(CompletionItemKind::VARIABLE),
-    //                         insert_text: Some(format!("{}=\"$1\"", name_string)),
-    //                         insert_text_format: Some(InsertTextFormat::SNIPPET),
-    //                         detail: Some(name_string),
-    //                         ..Default::default()
-    //                     });
-    //                 }
-    //             }
-    //         }
-    //         Some(ret)
-    //     }();
-    //     Ok(completions.map(CompletionResponse::Array))
-    // }
-
     // async fn rename(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
     //     let workspace_edit = || -> Option<WorkspaceEdit> {
     //         let uri = params.text_document_position.text_document.uri;

--- a/crates/fervid_lsp/src/main.rs
+++ b/crates/fervid_lsp/src/main.rs
@@ -148,7 +148,6 @@ impl LanguageServer for Backend {
     }
 
     async fn did_save(&self, params: DidSaveTextDocumentParams) {
-        dbg!(&params.text);
         if let Some(text) = params.text {
             let item = TextDocumentItem {
                 uri: params.text_document.uri,

--- a/crates/fervid_lsp/src/main.rs
+++ b/crates/fervid_lsp/src/main.rs
@@ -12,7 +12,7 @@ use tower_lsp::lsp_types::notification::Notification;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer, LspService, Server};
 
-use crate::completion::{provide_completions, FervidCompletionItem};
+use crate::completion::provide_completions;
 use crate::definition::goto_definition;
 use crate::nuxt::loader::load_nuxt_for_workspaces;
 use crate::nuxt::{NuxtGlobals, NuxtInfo};
@@ -62,7 +62,10 @@ impl LanguageServer for Backend {
         }
 
         Ok(InitializeResult {
-            server_info: None,
+            server_info: Some(ServerInfo {
+                name: env!("CARGO_PKG_NAME").to_string(),
+                version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            }),
             offset_encoding: None,
             capabilities: ServerCapabilities {
                 // inlay_hint_provider: Some(OneOf::Left(true)),
@@ -404,39 +407,7 @@ impl LanguageServer for Backend {
 
             let mut ret = Vec::with_capacity(completions.len());
             for item in completions {
-                match item {
-                    FervidCompletionItem::Component { name } => {
-                        let s = name.to_string();
-                        ret.push(CompletionItem {
-                            label: s.clone(),
-                            kind: Some(CompletionItemKind::CLASS),
-                            insert_text: Some(s.clone()),
-                            detail: Some("Nuxt component".into()),
-                            ..Default::default()
-                        });
-                    }
-                    FervidCompletionItem::Prop { name } => {
-                        let s = name.to_string();
-                        ret.push(CompletionItem {
-                            label: s.clone(),
-                            kind: Some(CompletionItemKind::VARIABLE),
-                            insert_text: Some(format!("{}=\"$1\"", s)),
-                            insert_text_format: Some(InsertTextFormat::SNIPPET),
-                            detail: Some("Vue prop".into()),
-                            ..Default::default()
-                        });
-                    }
-                    FervidCompletionItem::Import { name } => {
-                        let s = name.to_string();
-                        ret.push(CompletionItem {
-                            label: s.clone(),
-                            kind: Some(CompletionItemKind::FUNCTION),
-                            insert_text: Some(s.clone()),
-                            detail: Some("Nuxt auto-import".into()),
-                            ..Default::default()
-                        });
-                    }
-                }
+                ret.push(item.into());
             }
 
             Ok(Some(ret))

--- a/crates/fervid_lsp/src/nuxt/loader.rs
+++ b/crates/fervid_lsp/src/nuxt/loader.rs
@@ -1,0 +1,89 @@
+use std::sync::Arc;
+
+use tokio::fs;
+use tower_lsp::lsp_types::{MessageType, WorkspaceFolder};
+
+use crate::nuxt::parser::{parse_globals, ParseGlobalsResult};
+use crate::nuxt::NuxtInfo;
+use crate::utils::workspace_uri_to_path;
+use crate::Backend;
+
+pub async fn load_nuxt_for_workspaces(backend: &Backend, workspace_folders: &[WorkspaceFolder]) {
+    for workspace_folder in workspace_folders {
+        let Some(root) = workspace_uri_to_path(workspace_folder) else {
+            continue;
+        };
+        let root_key = root.to_string_lossy().to_string();
+
+        // Find .nuxt dir
+        let nuxt_dir = root.join(".nuxt");
+        if !nuxt_dir.is_dir() {
+            continue;
+        }
+
+        let imports_path = nuxt_dir.join("imports.d.ts");
+        let components_path = nuxt_dir.join("components.d.ts");
+
+        // Read files async, ignore missing
+        let imports_source = match fs::read_to_string(&imports_path).await {
+            Ok(s) => Some(s),
+            Err(_) => None,
+        };
+        let components_source = match fs::read_to_string(&components_path).await {
+            Ok(s) => Some(s),
+            Err(_) => None,
+        };
+
+        let ParseGlobalsResult {
+            globals,
+            is_error_loading_components,
+            is_error_loading_imports,
+        } = parse_globals(
+            imports_source.as_deref(),
+            &imports_path,
+            components_source.as_deref(),
+            &components_path,
+        );
+
+        // Store resolved paths even if missing
+        backend.nuxt_info.insert(
+            root_key.clone(),
+            Arc::new(NuxtInfo {
+                imports_dts: imports_path.exists().then_some(imports_path.clone()),
+                components_dts: components_path.exists().then_some(components_path.clone()),
+            }),
+        );
+
+        backend
+            .nuxt_globals
+            .insert(root_key.clone(), Arc::new(globals));
+
+        // Log warnings
+        if is_error_loading_imports {
+            let _ = backend
+                .client
+                .log_message(
+                    MessageType::WARNING,
+                    format!("Could not load imports.d.ts for {}", root_key),
+                )
+                .await;
+        }
+        if is_error_loading_components {
+            let _ = backend
+                .client
+                .log_message(
+                    MessageType::WARNING,
+                    format!("Could not load components.d.ts for {}", root_key),
+                )
+                .await;
+        }
+
+        let _ = backend
+            .client
+            .log_message(
+                MessageType::INFO,
+                format!("Loaded Nuxt globals for {}", root_key),
+            )
+            .await;
+    }
+}

--- a/crates/fervid_lsp/src/nuxt/loader.rs
+++ b/crates/fervid_lsp/src/nuxt/loader.rs
@@ -4,6 +4,7 @@ use tokio::fs;
 use tower_lsp::lsp_types::{MessageType, WorkspaceFolder};
 
 use crate::nuxt::parser::{parse_globals, ParseGlobalsResult};
+use crate::nuxt::resolver::resolve_global_paths;
 use crate::nuxt::NuxtInfo;
 use crate::utils::workspace_uri_to_path;
 use crate::Backend;
@@ -25,17 +26,11 @@ pub async fn load_nuxt_for_workspaces(backend: &Backend, workspace_folders: &[Wo
         let components_path = nuxt_dir.join("components.d.ts");
 
         // Read files async, ignore missing
-        let imports_source = match fs::read_to_string(&imports_path).await {
-            Ok(s) => Some(s),
-            Err(_) => None,
-        };
-        let components_source = match fs::read_to_string(&components_path).await {
-            Ok(s) => Some(s),
-            Err(_) => None,
-        };
+        let imports_source = fs::read_to_string(&imports_path).await.ok();
+        let components_source = fs::read_to_string(&components_path).await.ok();
 
         let ParseGlobalsResult {
-            globals,
+            mut globals,
             is_error_loading_components,
             is_error_loading_imports,
         } = parse_globals(
@@ -44,6 +39,8 @@ pub async fn load_nuxt_for_workspaces(backend: &Backend, workspace_folders: &[Wo
             components_source.as_deref(),
             &components_path,
         );
+
+        resolve_global_paths(&root, &mut globals).await;
 
         // Store resolved paths even if missing
         backend.nuxt_info.insert(

--- a/crates/fervid_lsp/src/nuxt/mod.rs
+++ b/crates/fervid_lsp/src/nuxt/mod.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use fervid_core::FervidAtom;
+
 pub mod loader;
 mod parser;
 pub mod resolver;
@@ -7,13 +9,32 @@ pub mod resolver;
 #[derive(Debug, Default)]
 pub struct NuxtInfo {
     /// Path to `.nuxt/imports.d.ts`
+    #[allow(dead_code)]
     pub imports_dts: Option<PathBuf>,
     /// Path to `.nuxt/components.d.ts`
+    #[allow(dead_code)]
     pub components_dts: Option<PathBuf>,
 }
 
 #[derive(Debug, Default)]
 pub struct NuxtGlobals {
-    pub imports: fxhash::FxHashMap<String, String>,
-    pub components: fxhash::FxHashMap<String, String>,
+    pub imports: fxhash::FxHashMap<FervidAtom, NuxtGlobalTarget>,
+    pub components: fxhash::FxHashMap<FervidAtom, NuxtGlobalTarget>,
+}
+
+#[derive(Debug, Default)]
+pub struct NuxtGlobalTarget {
+    /// Raw specifier from .d.ts
+    pub spec: FervidAtom,
+    /// Resolved filesystem path
+    pub resolved: Option<PathBuf>,
+}
+
+impl NuxtGlobalTarget {
+    pub fn new(spec: FervidAtom) -> Self {
+        NuxtGlobalTarget {
+            spec,
+            resolved: None,
+        }
+    }
 }

--- a/crates/fervid_lsp/src/nuxt/mod.rs
+++ b/crates/fervid_lsp/src/nuxt/mod.rs
@@ -1,0 +1,19 @@
+use std::path::PathBuf;
+
+pub mod loader;
+mod parser;
+pub mod resolver;
+
+#[derive(Debug, Default)]
+pub struct NuxtInfo {
+    /// Path to `.nuxt/imports.d.ts`
+    pub imports_dts: Option<PathBuf>,
+    /// Path to `.nuxt/components.d.ts`
+    pub components_dts: Option<PathBuf>,
+}
+
+#[derive(Debug, Default)]
+pub struct NuxtGlobals {
+    pub imports: fxhash::FxHashMap<String, String>,
+    pub components: fxhash::FxHashMap<String, String>,
+}

--- a/crates/fervid_lsp/src/nuxt/parser.rs
+++ b/crates/fervid_lsp/src/nuxt/parser.rs
@@ -1,0 +1,247 @@
+use std::{path::PathBuf, sync::Arc};
+
+use fxhash::FxHashMap;
+use swc_core::{
+    common::{FileName, SourceMap},
+    ecma::ast::{
+        Decl, ExportNamedSpecifier, ExportSpecifier, Module, ModuleDecl, ModuleExportName,
+        ModuleItem, Pat, TsType, TsTypeElement, TsTypeQuery, TsTypeQueryExpr,
+        TsUnionOrIntersectionType,
+    },
+};
+use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsSyntax};
+
+use crate::nuxt::NuxtGlobals;
+
+pub struct ParseGlobalsResult {
+    pub globals: NuxtGlobals,
+    pub is_error_loading_imports: bool,
+    pub is_error_loading_components: bool,
+}
+
+pub fn parse_globals(
+    imports_source: Option<&str>,
+    imports_path: &PathBuf,
+    components_source: Option<&str>,
+    components_path: &PathBuf,
+) -> ParseGlobalsResult {
+    // TODO Research a way to share the source map across threads from Backend?
+    let source_map = Arc::new(SourceMap::default());
+
+    // Parse the Nuxt files for globals
+    let mut errors = Vec::new();
+    let mut is_error_loading_imports = false;
+    let mut is_error_loading_components = false;
+
+    let imports = imports_source
+        .and_then(
+            |src| match parse_nuxt_imports_dts(src, &imports_path, source_map.clone()) {
+                Ok(v) => Some(v),
+                Err(error) => {
+                    errors.push(error);
+                    is_error_loading_imports = true;
+                    None
+                }
+            },
+        )
+        .unwrap_or_default();
+
+    let components = components_source
+        .and_then(|src| {
+            match parse_nuxt_components_dts(src, &components_path, source_map.clone()) {
+                Ok(v) => Some(v),
+                Err(error) => {
+                    errors.push(error);
+                    is_error_loading_components = true;
+                    None
+                }
+            }
+        })
+        .unwrap_or_default();
+
+    ParseGlobalsResult {
+        globals: NuxtGlobals {
+            imports,
+            components,
+        },
+        is_error_loading_components,
+        is_error_loading_imports,
+    }
+}
+
+fn parse_nuxt_components_dts(
+    source: &str,
+    path: &PathBuf,
+    cm: Arc<SourceMap>,
+) -> Result<FxHashMap<String, String>, swc_ecma_parser::error::Error> {
+    let module = parse_ts_module(source, path, &cm)?;
+    let mut out: FxHashMap<String, String> = FxHashMap::default();
+
+    for item in module.body {
+        let ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export_decl)) = item else {
+            continue;
+        };
+
+        let Decl::Var(var_decl) = &export_decl.decl else {
+            continue;
+        };
+
+        for decl in &var_decl.decls {
+            // export const X: <type>
+            let Pat::Ident(ident) = &decl.name else {
+                continue;
+            };
+            let Some(type_ann) = &ident.type_ann else {
+                continue;
+            };
+
+            if let Some(import_path) = find_first_import_type_path(&type_ann.type_ann) {
+                out.insert(ident.id.sym.to_string(), import_path);
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+fn parse_nuxt_imports_dts(
+    source: &str,
+    path: &PathBuf,
+    cm: Arc<SourceMap>,
+) -> Result<FxHashMap<String, String>, swc_ecma_parser::error::Error> {
+    let module = parse_ts_module(source, path, &cm)?;
+    let mut out: FxHashMap<String, String> = FxHashMap::default();
+
+    for item in module.body {
+        let ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named)) = item else {
+            continue;
+        };
+
+        // We only care about `export { ... } from "..."` (re-export)
+        let Some(src) = &named.src else {
+            continue;
+        };
+
+        let specifier = src.value.to_string();
+
+        for s in &named.specifiers {
+            match s {
+                ExportSpecifier::Named(ExportNamedSpecifier { exported, orig, .. }) => {
+                    // exported name (alias) if present, otherwise orig
+                    let name = exported
+                        .as_ref()
+                        .map(module_export_name_to_string)
+                        .unwrap_or_else(|| module_export_name_to_string(orig));
+
+                    out.insert(name, specifier.clone());
+                }
+                ExportSpecifier::Default(_) => {
+                    // `export { default as X } from ...` comes as Named with orig=Ident("default")
+                }
+                ExportSpecifier::Namespace(ns) => {
+                    // `export * as foo from "..."` -> foo
+                    let name = module_export_name_to_string(&ns.name);
+                    out.insert(name, specifier.clone());
+                }
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+// Walk TS types to find `import("...")` path.
+fn find_first_import_type_path(ty: &TsType) -> Option<String> {
+    match ty {
+        TsType::TsImportType(import_ty) => Some(import_ty.arg.value.to_string()),
+
+        TsType::TsTypeQuery(q) => {
+            // typeof import("...").default often becomes a TsTypeQuery whose expr_name
+            // contains TsImportType, depending on parsing form. So recursively inspect children.
+            find_import_in_type_query(q)
+        }
+
+        TsType::TsTypeRef(r) => {
+            // Unlikely here, but keep it recursive
+            r.type_params
+                .as_ref()?
+                .params
+                .iter()
+                .find_map(|arg0: &Box<TsType>| find_first_import_type_path(arg0))
+        }
+
+        TsType::TsTypeLit(lit) => {
+            for m in &lit.members {
+                if let TsTypeElement::TsPropertySignature(p) = m {
+                    if let Some(t) = &p.type_ann {
+                        if let Some(found) = find_first_import_type_path(&t.type_ann) {
+                            return Some(found);
+                        }
+                    }
+                }
+            }
+            None
+        }
+
+        TsType::TsUnionOrIntersectionType(u) => match u {
+            TsUnionOrIntersectionType::TsUnionType(u) => u
+                .types
+                .iter()
+                .find_map(|arg0: &Box<TsType>| find_first_import_type_path(arg0)),
+            TsUnionOrIntersectionType::TsIntersectionType(i) => i
+                .types
+                .iter()
+                .find_map(|arg0: &Box<TsType>| find_first_import_type_path(arg0)),
+        },
+
+        TsType::TsParenthesizedType(p) => find_first_import_type_path(&p.type_ann),
+
+        TsType::TsIndexedAccessType(i) => find_first_import_type_path(&i.obj_type)
+            .or_else(|| find_first_import_type_path(&i.index_type)),
+
+        TsType::TsTypeOperator(op) => find_first_import_type_path(&op.type_ann),
+
+        TsType::TsConditionalType(c) => find_first_import_type_path(&c.check_type)
+            .or_else(|| find_first_import_type_path(&c.extends_type))
+            .or_else(|| find_first_import_type_path(&c.true_type))
+            .or_else(|| find_first_import_type_path(&c.false_type)),
+
+        _ => None,
+    }
+}
+
+fn find_import_in_type_query(q: &TsTypeQuery) -> Option<String> {
+    match &q.expr_name {
+        TsTypeQueryExpr::Import(import_ty) => Some(import_ty.arg.value.to_string()),
+        TsTypeQueryExpr::TsEntityName(_) => None,
+    }
+}
+
+fn module_export_name_to_string(n: &ModuleExportName) -> String {
+    match n {
+        ModuleExportName::Ident(i) => i.sym.to_string(),
+        ModuleExportName::Str(s) => s.value.to_string(),
+    }
+}
+
+fn parse_ts_module(
+    source: &str,
+    path: &PathBuf,
+    cm: &SourceMap,
+) -> Result<Module, swc_ecma_parser::error::Error> {
+    let filename = FileName::Real(path.to_owned());
+    let fm = cm.new_source_file(filename.into(), source.to_string());
+
+    let lexer = Lexer::new(
+        Syntax::Typescript(TsSyntax::default()),
+        Default::default(),
+        StringInput::from(&*fm),
+        None,
+    );
+
+    let mut parser = Parser::new_from(lexer);
+    let module = parser.parse_module()?;
+
+    // TODO: collect parser.take_errors() and log them
+    Ok(module)
+}

--- a/crates/fervid_lsp/src/nuxt/parser.rs
+++ b/crates/fervid_lsp/src/nuxt/parser.rs
@@ -1,5 +1,6 @@
 use std::{path::PathBuf, sync::Arc};
 
+use fervid_core::FervidAtom;
 use fxhash::FxHashMap;
 use swc_core::{
     common::{FileName, SourceMap},
@@ -11,7 +12,7 @@ use swc_core::{
 };
 use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsSyntax};
 
-use crate::nuxt::NuxtGlobals;
+use crate::nuxt::{NuxtGlobalTarget, NuxtGlobals};
 
 pub struct ParseGlobalsResult {
     pub globals: NuxtGlobals,
@@ -35,7 +36,7 @@ pub fn parse_globals(
 
     let imports = imports_source
         .and_then(
-            |src| match parse_nuxt_imports_dts(src, &imports_path, source_map.clone()) {
+            |src| match parse_nuxt_imports_dts(src, imports_path, source_map.clone()) {
                 Ok(v) => Some(v),
                 Err(error) => {
                     errors.push(error);
@@ -47,16 +48,16 @@ pub fn parse_globals(
         .unwrap_or_default();
 
     let components = components_source
-        .and_then(|src| {
-            match parse_nuxt_components_dts(src, &components_path, source_map.clone()) {
+        .and_then(
+            |src| match parse_nuxt_components_dts(src, components_path, source_map.clone()) {
                 Ok(v) => Some(v),
                 Err(error) => {
                     errors.push(error);
                     is_error_loading_components = true;
                     None
                 }
-            }
-        })
+            },
+        )
         .unwrap_or_default();
 
     ParseGlobalsResult {
@@ -73,9 +74,9 @@ fn parse_nuxt_components_dts(
     source: &str,
     path: &PathBuf,
     cm: Arc<SourceMap>,
-) -> Result<FxHashMap<String, String>, swc_ecma_parser::error::Error> {
+) -> Result<FxHashMap<FervidAtom, NuxtGlobalTarget>, swc_ecma_parser::error::Error> {
     let module = parse_ts_module(source, path, &cm)?;
-    let mut out: FxHashMap<String, String> = FxHashMap::default();
+    let mut out: FxHashMap<FervidAtom, NuxtGlobalTarget> = FxHashMap::default();
 
     for item in module.body {
         let ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export_decl)) = item else {
@@ -96,7 +97,7 @@ fn parse_nuxt_components_dts(
             };
 
             if let Some(import_path) = find_first_import_type_path(&type_ann.type_ann) {
-                out.insert(ident.id.sym.to_string(), import_path);
+                out.insert(ident.id.sym.to_owned(), NuxtGlobalTarget::new(import_path));
             }
         }
     }
@@ -108,9 +109,9 @@ fn parse_nuxt_imports_dts(
     source: &str,
     path: &PathBuf,
     cm: Arc<SourceMap>,
-) -> Result<FxHashMap<String, String>, swc_ecma_parser::error::Error> {
+) -> Result<FxHashMap<FervidAtom, NuxtGlobalTarget>, swc_ecma_parser::error::Error> {
     let module = parse_ts_module(source, path, &cm)?;
-    let mut out: FxHashMap<String, String> = FxHashMap::default();
+    let mut out: FxHashMap<FervidAtom, NuxtGlobalTarget> = FxHashMap::default();
 
     for item in module.body {
         let ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named)) = item else {
@@ -122,7 +123,7 @@ fn parse_nuxt_imports_dts(
             continue;
         };
 
-        let specifier = src.value.to_string();
+        let specifier = src.value.to_owned();
 
         for s in &named.specifiers {
             match s {
@@ -133,7 +134,7 @@ fn parse_nuxt_imports_dts(
                         .map(module_export_name_to_string)
                         .unwrap_or_else(|| module_export_name_to_string(orig));
 
-                    out.insert(name, specifier.clone());
+                    out.insert(name, NuxtGlobalTarget::new(specifier.to_owned()));
                 }
                 ExportSpecifier::Default(_) => {
                     // `export { default as X } from ...` comes as Named with orig=Ident("default")
@@ -141,7 +142,7 @@ fn parse_nuxt_imports_dts(
                 ExportSpecifier::Namespace(ns) => {
                     // `export * as foo from "..."` -> foo
                     let name = module_export_name_to_string(&ns.name);
-                    out.insert(name, specifier.clone());
+                    out.insert(name, NuxtGlobalTarget::new(specifier.to_owned()));
                 }
             }
         }
@@ -150,10 +151,10 @@ fn parse_nuxt_imports_dts(
     Ok(out)
 }
 
-// Walk TS types to find `import("...")` path.
-fn find_first_import_type_path(ty: &TsType) -> Option<String> {
+/// Walk TS types to find `import("...")` path.
+fn find_first_import_type_path(ty: &TsType) -> Option<FervidAtom> {
     match ty {
-        TsType::TsImportType(import_ty) => Some(import_ty.arg.value.to_string()),
+        TsType::TsImportType(import_ty) => Some(import_ty.arg.value.to_owned()),
 
         TsType::TsTypeQuery(q) => {
             // typeof import("...").default often becomes a TsTypeQuery whose expr_name
@@ -167,7 +168,7 @@ fn find_first_import_type_path(ty: &TsType) -> Option<String> {
                 .as_ref()?
                 .params
                 .iter()
-                .find_map(|arg0: &Box<TsType>| find_first_import_type_path(arg0))
+                .find_map(|arg0| find_first_import_type_path(arg0))
         }
 
         TsType::TsTypeLit(lit) => {
@@ -187,11 +188,11 @@ fn find_first_import_type_path(ty: &TsType) -> Option<String> {
             TsUnionOrIntersectionType::TsUnionType(u) => u
                 .types
                 .iter()
-                .find_map(|arg0: &Box<TsType>| find_first_import_type_path(arg0)),
+                .find_map(|arg0| find_first_import_type_path(arg0)),
             TsUnionOrIntersectionType::TsIntersectionType(i) => i
                 .types
                 .iter()
-                .find_map(|arg0: &Box<TsType>| find_first_import_type_path(arg0)),
+                .find_map(|arg0| find_first_import_type_path(arg0)),
         },
 
         TsType::TsParenthesizedType(p) => find_first_import_type_path(&p.type_ann),
@@ -210,17 +211,17 @@ fn find_first_import_type_path(ty: &TsType) -> Option<String> {
     }
 }
 
-fn find_import_in_type_query(q: &TsTypeQuery) -> Option<String> {
+fn find_import_in_type_query(q: &TsTypeQuery) -> Option<FervidAtom> {
     match &q.expr_name {
-        TsTypeQueryExpr::Import(import_ty) => Some(import_ty.arg.value.to_string()),
+        TsTypeQueryExpr::Import(import_ty) => Some(import_ty.arg.value.to_owned()),
         TsTypeQueryExpr::TsEntityName(_) => None,
     }
 }
 
-fn module_export_name_to_string(n: &ModuleExportName) -> String {
+fn module_export_name_to_string(n: &ModuleExportName) -> FervidAtom {
     match n {
-        ModuleExportName::Ident(i) => i.sym.to_string(),
-        ModuleExportName::Str(s) => s.value.to_string(),
+        ModuleExportName::Ident(i) => i.sym.to_owned(),
+        ModuleExportName::Str(s) => s.value.to_owned(),
     }
 }
 

--- a/crates/fervid_lsp/src/nuxt/resolver.rs
+++ b/crates/fervid_lsp/src/nuxt/resolver.rs
@@ -1,0 +1,7 @@
+use std::path::{Path, PathBuf};
+
+pub fn resolve_from_nuxt_dir(workspace_root: &Path, import_path: &str) -> PathBuf {
+    // import_path is relative to .nuxt
+    let nuxt_dir = workspace_root.join(".nuxt");
+    nuxt_dir.join(import_path)
+}

--- a/crates/fervid_lsp/src/nuxt/resolver.rs
+++ b/crates/fervid_lsp/src/nuxt/resolver.rs
@@ -1,7 +1,140 @@
+use crate::{
+    nuxt::{NuxtGlobalTarget, NuxtGlobals},
+    utils::normalize_path,
+};
 use std::path::{Path, PathBuf};
+use tokio::task::JoinSet;
 
-pub fn resolve_from_nuxt_dir(workspace_root: &Path, import_path: &str) -> PathBuf {
+const EXT_CANDIDATES: &[&str] = &[
+    "ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs", "d.ts", "d.mts", "vue",
+];
+
+/// Resolve all globals' filesystem paths and cache them into `resolved`.
+pub async fn resolve_global_paths(workspace_root: &Path, globals: &mut NuxtGlobals) {
+    // Imports
+    for (_name, target) in globals.imports.iter_mut() {
+        resolve_one_target(workspace_root, target).await;
+    }
+
+    // Components
+    for (_name, target) in globals.components.iter_mut() {
+        resolve_one_target(workspace_root, target).await;
+    }
+}
+
+async fn resolve_one_target(workspace_root: &Path, target: &mut NuxtGlobalTarget) {
+    // Skip if already resolved
+    if target.resolved.is_some() {
+        return;
+    }
+
+    let spec_str = target.spec.as_ref();
+    if is_bare_or_alias(spec_str) {
+        // Can't resolve "vue-demi" etc here; keep unresolved.
+        // TODO
+        return;
+    }
+
+    let candidates = get_candidates_for_spec(workspace_root, spec_str);
+
+    if let Some(found) = find_best_existing_path(candidates).await {
+        target.resolved = Some(normalize_path(found));
+    }
+}
+
+fn module_candidates_from_nuxt_dir(workspace_root: &Path, import_path: &str) -> Vec<PathBuf> {
     // import_path is relative to .nuxt
     let nuxt_dir = workspace_root.join(".nuxt");
-    nuxt_dir.join(import_path)
+    module_candidates_from_base(&nuxt_dir, import_path)
+}
+
+/// Build candidates for a spec, interpreting it relative to `.nuxt/` when appropriate.
+/// If spec already has an extension, candidates include the direct path.
+fn get_candidates_for_spec(workspace_root: &Path, spec: &str) -> Vec<PathBuf> {
+    // Absolute paths: just try as-is (+ optional index forms if no ext)
+    if spec.starts_with('/') || spec.starts_with(r"\\") || spec.contains(':') {
+        return module_candidates_from_base(Path::new(""), spec);
+    }
+
+    // Relative to .nuxt
+    module_candidates_from_nuxt_dir(workspace_root, spec)
+}
+
+/// Same candidate logic as before, but with an arbitrary base.
+/// Used to support absolute paths (base == "").
+fn module_candidates_from_base(base: &Path, spec: &str) -> Vec<PathBuf> {
+    let spec_path = Path::new(spec);
+    let mut out = Vec::new();
+
+    // Use direct path if file extension is present
+    if spec_path.extension().is_some() {
+        out.push(base.join(spec));
+        return out;
+    }
+
+    // 1) <spec>.<ext>
+    for ext in EXT_CANDIDATES {
+        out.push(base.join(format!("{spec}.{ext}")));
+    }
+
+    // 2) <spec>/index.<ext>
+    let sub_dir = base.join(spec);
+    for ext in EXT_CANDIDATES {
+        out.push(sub_dir.join(format!("index.{ext}")));
+    }
+
+    out
+}
+
+async fn find_best_existing_path(candidates: Vec<PathBuf>) -> Option<PathBuf> {
+    let mut set = JoinSet::new();
+
+    for (priority, candidate) in candidates.into_iter().enumerate() {
+        set.spawn(try_exists_with_priority(candidate, priority));
+    }
+
+    let results = set.join_all().await;
+    let mut best_candidate = None;
+    for result in results {
+        let Ok(result) = result else {
+            continue;
+        };
+
+        match best_candidate {
+            None => best_candidate = Some(result),
+            // Lower number = higher priority
+            Some(existing_best) if result.1 < existing_best.1 => best_candidate = Some(result),
+            _ => {}
+        }
+    }
+
+    best_candidate.map(|v| v.0)
+}
+
+async fn try_exists_with_priority(
+    path: PathBuf,
+    priority: usize,
+) -> Result<(PathBuf, usize), std::io::Error> {
+    match tokio::fs::try_exists(&path).await {
+        Ok(true) => Ok((path, priority)),
+        Ok(false) => Err(std::io::Error::new(std::io::ErrorKind::NotFound, "")),
+        Err(e) => Err(e),
+    }
+}
+
+/// Decide whether a spec looks like a filesystem-like path we can resolve
+fn is_path_like(spec: &str) -> bool {
+    spec.starts_with("./")
+        || spec.starts_with("../")
+        || spec.starts_with('/') // unix absolute
+        || spec.starts_with(r"\\") // windows UNC
+        || spec.contains(':') // windows drive like C:\...
+}
+
+// TODO: Implement it
+/// Bare specifiers like "vue-demi", "@vueuse/core", "#app/..." are NOT resolved here.
+fn is_bare_or_alias(spec: &str) -> bool {
+    // "foo", "@scope/foo", "#app/...", "~", "@", etc
+    // For now, treat anything not path-like as non-resolvable
+    !is_path_like(spec)
 }

--- a/crates/fervid_lsp/src/structs.rs
+++ b/crates/fervid_lsp/src/structs.rs
@@ -1,0 +1,52 @@
+use crate::nuxt::{NuxtGlobals, NuxtInfo};
+use dashmap::DashMap;
+use fervid_core::{SfcDescriptor, SfcTemplateBlock};
+use fervid_transform::BindingsHelper;
+use ropey::Rope;
+use std::{
+    path::PathBuf,
+    sync::{Arc, RwLock},
+};
+use tower_lsp::{lsp_types::Url, Client};
+
+type WorkspaceKey = String;
+
+#[derive(Debug)]
+pub struct Backend {
+    pub client: Client,
+
+    // TODO: We should probably store information in Workspace structs instead
+    /// Map for storing the raw initial AST by file URI, where AST is the full SFC descriptor
+    pub ast_map: Arc<DashMap<String, SfcDescriptor>>,
+
+    /// Map for storing the results of document analysis, such as bindings, etc.
+    pub analysis_map: Arc<DashMap<String, Arc<DocumentAnalysis>>>,
+
+    /// Map for storing the contents of the document
+    pub document_map: DashMap<String, Rope>,
+
+    /// Workspace directories of the project
+    pub workspace_roots: RwLock<Vec<PathBuf>>,
+
+    // semantic_map: DashMap<String, Semantic>,
+    // semantic_token_map: DashMap<String, Vec<ImCompleteSemanticToken>>,
+
+    // Nuxt-specific
+    pub nuxt_info: DashMap<WorkspaceKey, Arc<NuxtInfo>>,
+    pub nuxt_globals: DashMap<WorkspaceKey, Arc<NuxtGlobals>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DocumentAnalysis {
+    #[allow(unused)]
+    pub version: Option<i32>,
+    pub bindings: Arc<BindingsHelper>,
+    #[allow(unused)]
+    pub template_block: Option<SfcTemplateBlock>,
+}
+
+pub struct TextDocumentItem<'a> {
+    pub uri: Url,
+    pub text: &'a str,
+    pub version: Option<i32>,
+}

--- a/crates/fervid_lsp/src/utils.rs
+++ b/crates/fervid_lsp/src/utils.rs
@@ -1,4 +1,4 @@
-use std::path::{Component, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use ropey::Rope;
 use tower_lsp::lsp_types::{Url, WorkspaceFolder};
@@ -15,7 +15,7 @@ pub fn uri_to_path(uri: &Url) -> Option<std::path::PathBuf> {
     uri.to_file_path().ok()
 }
 
-pub fn pick_workspace_root<'a>(roots: &'a [PathBuf], file: &PathBuf) -> Option<&'a PathBuf> {
+pub fn pick_workspace_root<'a>(roots: &'a [PathBuf], file: &Path) -> Option<&'a PathBuf> {
     roots
         .iter()
         .filter(|root_path| file.starts_with(root_path))

--- a/crates/fervid_lsp/src/utils.rs
+++ b/crates/fervid_lsp/src/utils.rs
@@ -1,0 +1,97 @@
+use std::path::{Component, PathBuf};
+
+use ropey::Rope;
+use tower_lsp::lsp_types::{Url, WorkspaceFolder};
+
+pub fn workspace_uri_to_path(workspace_folder: &WorkspaceFolder) -> Option<std::path::PathBuf> {
+    uri_to_path(&workspace_folder.uri)
+}
+
+pub fn uri_to_path(uri: &Url) -> Option<std::path::PathBuf> {
+    if uri.scheme() != "file" {
+        return None;
+    }
+
+    uri.to_file_path().ok()
+}
+
+pub fn pick_workspace_root<'a>(roots: &'a [PathBuf], file: &PathBuf) -> Option<&'a PathBuf> {
+    roots
+        .iter()
+        .filter(|root_path| file.starts_with(root_path))
+        .max_by_key(|root_path| root_path.as_os_str().len())
+}
+
+pub fn is_ident_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_' || c == '$' || c == '-'
+}
+
+/// Extracts prefix from the current cursor.
+/// Example: if cursor | is at som|ething, the extracted prefix is `som`
+pub fn extract_prefix(rope: &Rope, cursor_char: usize) -> String {
+    let mut start = cursor_char;
+
+    while start > 0 {
+        let c = rope.char(start - 1);
+        if is_ident_char(c) {
+            start -= 1;
+        } else {
+            break;
+        }
+    }
+
+    rope.slice(start..cursor_char).to_string()
+}
+
+/// Extracts the full token under the current cursor.
+/// Example: if cursor | is at som|ething, the extracted token is `something`
+pub fn extract_token_at(rope: &ropey::Rope, cursor_char: usize) -> String {
+    let len = rope.len_chars();
+    if cursor_char > len {
+        return String::new();
+    }
+
+    // If cursor is at end of token, step left once (nice UX)
+    let mut i = cursor_char;
+    if i > 0 && (i == len || !is_ident_char(rope.char(i))) && is_ident_char(rope.char(i - 1)) {
+        i -= 1;
+    }
+
+    let mut start = i;
+    while start > 0 && is_ident_char(rope.char(start - 1)) {
+        start -= 1;
+    }
+
+    let mut end = i + 1;
+    while end < len && is_ident_char(rope.char(end)) {
+        end += 1;
+    }
+
+    rope.slice(start..end).to_string()
+}
+
+/// Naive implementation of path normalization without resorting to `canonicalize`
+/// and fs access
+pub fn normalize_path(p: PathBuf) -> PathBuf {
+    let mut stack: Vec<std::ffi::OsString> = Vec::new();
+
+    for c in p.components() {
+        match c {
+            Component::ParentDir => {
+                stack.pop();
+            }
+            Component::CurDir => {}
+            Component::RootDir | Component::Prefix(_) => {
+                stack.clear();
+                stack.push(c.as_os_str().to_os_string());
+            }
+            Component::Normal(s) => stack.push(s.to_os_string()),
+        }
+    }
+
+    let mut out = PathBuf::new();
+    for s in stack {
+        out.push(s);
+    }
+    out
+}

--- a/crates/fervid_lsp/src/utils.rs
+++ b/crates/fervid_lsp/src/utils.rs
@@ -27,7 +27,7 @@ pub fn is_ident_char(c: char) -> bool {
 }
 
 /// Extracts prefix from the current cursor.
-/// Example: if cursor | is at som|ething, the extracted prefix is `som`
+/// Example: if cursor | is at some|thing, the extracted prefix is `some`
 pub fn extract_prefix(rope: &Rope, cursor_char: usize) -> String {
     let mut start = cursor_char;
 
@@ -44,7 +44,7 @@ pub fn extract_prefix(rope: &Rope, cursor_char: usize) -> String {
 }
 
 /// Extracts the full token under the current cursor.
-/// Example: if cursor | is at som|ething, the extracted token is `something`
+/// Example: if cursor | is at some|thing, the extracted token is `something`
 pub fn extract_token_at(rope: &ropey::Rope, cursor_char: usize) -> String {
     let len = rope.len_chars();
     if cursor_char > len {

--- a/crates/fervid_transform/src/error.rs
+++ b/crates/fervid_transform/src/error.rs
@@ -130,3 +130,9 @@ impl Spanned for TransformError {
         }
     }
 }
+
+impl std::fmt::Display for TransformError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}

--- a/cspell.json
+++ b/cspell.json
@@ -141,7 +141,8 @@
     "clippy",
     "dashmap",
     "ropey",
-    "indexmap"
+    "indexmap",
+    "nuxt"
   ],
   "ignorePaths": [
     ".github/**",

--- a/cspell.json
+++ b/cspell.json
@@ -142,7 +142,9 @@
     "dashmap",
     "ropey",
     "indexmap",
-    "nuxt"
+    "nuxt",
+    "vueuse",
+    "demi"
   ],
   "ignorePaths": [
     ".github/**",


### PR DESCRIPTION
Contributes to #29

This adds a super basic LSP server tailored for use with Nuxt projects. The server was born out of frustration of multiple different tools not working with medium-to-large (50K+ LOC) Nuxt codebases.

Currently only implements the very simple functionality:
- Autocompletion of Nuxt auto-importable component and symbol names (see https://nuxt.com/docs/4.x/examples/features/auto-imports) - with limitation to only prefix-matching and no context awareness yet;
- Click-through on known components and symbol names (same set as for autocompletion);
- Displaying parsing errors as diagnostics;

## Try it

For a (very concise) guide on how to use it, refer to [`crates/fervid_lsp/README.md`](https://github.com/phoenix-ru/fervid/blob/feat/29-implement-lsp-for-nuxt/crates/fervid_lsp/README.md)
